### PR TITLE
Update to support module/moduleResolution: node16, and module: esnext + moduleResolution: node

### DIFF
--- a/b+tree.d.ts
+++ b/b+tree.d.ts
@@ -1,6 +1,6 @@
 import { ISortedMap, ISortedMapF, ISortedSet } from './interfaces';
 export { ISetSource, ISetSink, ISet, ISetF, ISortedSetSource, ISortedSet, ISortedSetF, IMapSource, IMapSink, IMap, IMapF, ISortedMapSource, ISortedMap, ISortedMapF } from './interfaces';
-export declare type EditRangeResult<V, R = number> = {
+export type EditRangeResult<V, R = number> = {
     value?: V;
     break?: R;
     delete?: boolean;
@@ -8,7 +8,7 @@ export declare type EditRangeResult<V, R = number> = {
 /**
  * Types that BTree supports by default
  */
-export declare type DefaultComparable = number | string | Date | boolean | null | undefined | (number | string)[] | {
+export type DefaultComparable = number | string | Date | boolean | null | undefined | (number | string)[] | {
     valueOf: () => number | string | Date | boolean | null | undefined | (number | string)[];
 };
 /**
@@ -103,7 +103,7 @@ export declare function simpleComparator(a: (number | string)[], b: (number | st
  *
  * @author David Piepgrass
  */
-export default class BTree<K = any, V = any> implements ISortedMapF<K, V>, ISortedMap<K, V> {
+export declare class BTree<K = any, V = any> implements ISortedMapF<K, V>, ISortedMap<K, V> {
     private _root;
     _size: number;
     _maxNodeSize: number;

--- a/b+tree.js
+++ b/b+tree.js
@@ -1,21 +1,6 @@
 "use strict";
-var __extends = (this && this.__extends) || (function () {
-    var extendStatics = function (d, b) {
-        extendStatics = Object.setPrototypeOf ||
-            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
-        return extendStatics(d, b);
-    };
-    return function (d, b) {
-        if (typeof b !== "function" && b !== null)
-            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
-        extendStatics(d, b);
-        function __() { this.constructor = d; }
-        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-    };
-})();
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.EmptyBTree = exports.asSet = exports.simpleComparator = exports.defaultComparator = void 0;
+exports.EmptyBTree = exports.asSet = exports.BTree = exports.simpleComparator = exports.defaultComparator = void 0;
 /**
  * Compares DefaultComparables to form a strict partial ordering.
  *
@@ -30,15 +15,15 @@ exports.EmptyBTree = exports.asSet = exports.simpleComparator = exports.defaultC
 function defaultComparator(a, b) {
     // Special case finite numbers first for performance.
     // Note that the trick of using 'a - b' and checking for NaN to detect non-numbers
-    // does not work if the strings are numeric (ex: "5"). This would leading most 
+    // does not work if the strings are numeric (ex: "5"). This would leading most
     // comparison functions using that approach to fail to have transitivity.
     if (Number.isFinite(a) && Number.isFinite(b)) {
         return a - b;
     }
     // The default < and > operators are not totally ordered. To allow types to be mixed
     // in a single collection, compare types and order values of different types by type.
-    var ta = typeof a;
-    var tb = typeof b;
+    let ta = typeof a;
+    let tb = typeof b;
     if (ta !== tb) {
         return ta < tb ? -1 : 1;
     }
@@ -57,7 +42,7 @@ function defaultComparator(a, b) {
             return ta < tb ? -1 : 1;
         }
     }
-    // a and b are now the same type, and will be a number, string or array 
+    // a and b are now the same type, and will be a number, string or array
     // (which we assume holds numbers or strings), or something unsupported.
     if (a < b)
         return -1;
@@ -144,7 +129,7 @@ exports.simpleComparator = simpleComparator;
  *
  * @author David Piepgrass
  */
-var BTree = /** @class */ (function () {
+class BTree {
     /**
      * Initializes an empty B+ tree.
      * @param compare Custom function to compare pairs of elements in the tree.
@@ -153,7 +138,7 @@ var BTree = /** @class */ (function () {
      * @param maxNodeSize Branching factor (maximum items or children per node)
      *   Must be in range 4..256. If undefined or <4 then default is used; if >256 then 256.
      */
-    function BTree(entries, compare, maxNodeSize) {
+    constructor(entries, compare, maxNodeSize) {
         this._root = EmptyLeaf;
         this._size = 0;
         this._maxNodeSize = maxNodeSize >= 4 ? Math.min(maxNodeSize, 256) : 32;
@@ -161,31 +146,19 @@ var BTree = /** @class */ (function () {
         if (entries)
             this.setPairs(entries);
     }
-    Object.defineProperty(BTree.prototype, "size", {
-        /////////////////////////////////////////////////////////////////////////////
-        // ES6 Map<K,V> methods /////////////////////////////////////////////////////
-        /** Gets the number of key-value pairs in the tree. */
-        get: function () { return this._size; },
-        enumerable: false,
-        configurable: true
-    });
-    Object.defineProperty(BTree.prototype, "length", {
-        /** Gets the number of key-value pairs in the tree. */
-        get: function () { return this._size; },
-        enumerable: false,
-        configurable: true
-    });
-    Object.defineProperty(BTree.prototype, "isEmpty", {
-        /** Returns true iff the tree contains no key-value pairs. */
-        get: function () { return this._size === 0; },
-        enumerable: false,
-        configurable: true
-    });
+    /////////////////////////////////////////////////////////////////////////////
+    // ES6 Map<K,V> methods /////////////////////////////////////////////////////
+    /** Gets the number of key-value pairs in the tree. */
+    get size() { return this._size; }
+    /** Gets the number of key-value pairs in the tree. */
+    get length() { return this._size; }
+    /** Returns true iff the tree contains no key-value pairs. */
+    get isEmpty() { return this._size === 0; }
     /** Releases the tree so that its size is 0. */
-    BTree.prototype.clear = function () {
+    clear() {
         this._root = EmptyLeaf;
         this._size = 0;
-    };
+    }
     /** Runs a function for each key-value pair, in order from smallest to
      *  largest key. For compatibility with ES6 Map, the argument order to
      *  the callback is backwards: value first, then key. Call forEachPair
@@ -194,12 +167,11 @@ var BTree = /** @class */ (function () {
      *        value for each callback.
      * @returns the number of values that were sent to the callback,
      *        or the R value if the callback returned {break:R}. */
-    BTree.prototype.forEach = function (callback, thisArg) {
-        var _this = this;
+    forEach(callback, thisArg) {
         if (thisArg !== undefined)
             callback = callback.bind(thisArg);
-        return this.forEachPair(function (k, v) { return callback(v, k, _this); });
-    };
+        return this.forEachPair((k, v) => callback(v, k, this));
+    }
     /** Runs a function for each key-value pair, in order from smallest to
      *  largest key. The callback can return {break:R} (where R is any value
      *  except undefined) to stop immediately and return R from forEachPair.
@@ -214,19 +186,19 @@ var BTree = /** @class */ (function () {
      * @returns the number of pairs sent to the callback (plus initialCounter,
      *        if you provided one). If the callback returned {break:R} then
      *        the R value is returned instead. */
-    BTree.prototype.forEachPair = function (callback, initialCounter) {
+    forEachPair(callback, initialCounter) {
         var low = this.minKey(), high = this.maxKey();
         return this.forRange(low, high, true, callback, initialCounter);
-    };
+    }
     /**
      * Finds a pair in the tree and returns the associated value.
      * @param defaultValue a value to return if the key was not found.
      * @returns the value, or defaultValue if the key was not found.
      * @description Computational complexity: O(log size)
      */
-    BTree.prototype.get = function (key, defaultValue) {
+    get(key, defaultValue) {
         return this._root.get(key, defaultValue, this);
-    };
+    }
     /**
      * Adds or overwrites a key-value pair in the B+ tree.
      * @param key the key is used to determine the sort order of
@@ -241,7 +213,7 @@ var BTree = /** @class */ (function () {
      * as well as the value. This has no effect unless the new key
      * has data that does not affect its sort order.
      */
-    BTree.prototype.set = function (key, value, overwrite) {
+    set(key, value, overwrite) {
         if (this._root.isShared)
             this._root = this._root.clone();
         var result = this._root.set(key, value, overwrite, this);
@@ -250,7 +222,7 @@ var BTree = /** @class */ (function () {
         // Root node has split, so create a new root node.
         this._root = new BNodeInternal([this._root, result]);
         return true;
-    };
+    }
     /**
      * Returns true if the key exists in the B+ tree, false if not.
      * Use get() for best performance; use has() if you need to
@@ -258,27 +230,27 @@ var BTree = /** @class */ (function () {
      * @param key Key to detect
      * @description Computational complexity: O(log size)
      */
-    BTree.prototype.has = function (key) {
+    has(key) {
         return this.forRange(key, key, true, undefined) !== 0;
-    };
+    }
     /**
      * Removes a single key-value pair from the B+ tree.
      * @param key Key to find
      * @returns true if a pair was found and removed, false otherwise.
      * @description Computational complexity: O(log size)
      */
-    BTree.prototype.delete = function (key) {
+    delete(key) {
         return this.editRange(key, key, true, DeleteRange) !== 0;
-    };
-    BTree.prototype.with = function (key, value, overwrite) {
-        var nu = this.clone();
+    }
+    with(key, value, overwrite) {
+        let nu = this.clone();
         return nu.set(key, value, overwrite) || overwrite ? nu : this;
-    };
+    }
     /** Returns a copy of the tree with the specified key-value pairs set. */
-    BTree.prototype.withPairs = function (pairs, overwrite) {
-        var nu = this.clone();
+    withPairs(pairs, overwrite) {
+        let nu = this.clone();
         return nu.setPairs(pairs, overwrite) !== 0 || overwrite ? nu : this;
-    };
+    }
     /** Returns a copy of the tree with the specified keys present.
      *  @param keys The keys to add. If a key is already present in the tree,
      *         neither the existing key nor the existing value is modified.
@@ -287,67 +259,67 @@ var BTree = /** @class */ (function () {
      *  node(s) leading to existing keys are cloned even if the collection is
      *  ultimately unchanged.
     */
-    BTree.prototype.withKeys = function (keys, returnThisIfUnchanged) {
-        var nu = this.clone(), changed = false;
+    withKeys(keys, returnThisIfUnchanged) {
+        let nu = this.clone(), changed = false;
         for (var i = 0; i < keys.length; i++)
             changed = nu.set(keys[i], undefined, false) || changed;
         return returnThisIfUnchanged && !changed ? this : nu;
-    };
+    }
     /** Returns a copy of the tree with the specified key removed.
      * @param returnThisIfUnchanged if true, returns this if the key didn't exist.
      *  Performance note: due to the architecture of this class, node(s) leading
      *  to where the key would have been stored are cloned even when the key
      *  turns out not to exist and the collection is unchanged.
      */
-    BTree.prototype.without = function (key, returnThisIfUnchanged) {
+    without(key, returnThisIfUnchanged) {
         return this.withoutRange(key, key, true, returnThisIfUnchanged);
-    };
+    }
     /** Returns a copy of the tree with the specified keys removed.
      * @param returnThisIfUnchanged if true, returns this if none of the keys
      *  existed. Performance note: due to the architecture of this class,
      *  node(s) leading to where the key would have been stored are cloned
      *  even when the key turns out not to exist.
      */
-    BTree.prototype.withoutKeys = function (keys, returnThisIfUnchanged) {
-        var nu = this.clone();
+    withoutKeys(keys, returnThisIfUnchanged) {
+        let nu = this.clone();
         return nu.deleteKeys(keys) || !returnThisIfUnchanged ? nu : this;
-    };
+    }
     /** Returns a copy of the tree with the specified range of keys removed. */
-    BTree.prototype.withoutRange = function (low, high, includeHigh, returnThisIfUnchanged) {
-        var nu = this.clone();
+    withoutRange(low, high, includeHigh, returnThisIfUnchanged) {
+        let nu = this.clone();
         if (nu.deleteRange(low, high, includeHigh) === 0 && returnThisIfUnchanged)
             return this;
         return nu;
-    };
+    }
     /** Returns a copy of the tree with pairs removed whenever the callback
      *  function returns false. `where()` is a synonym for this method. */
-    BTree.prototype.filter = function (callback, returnThisIfUnchanged) {
+    filter(callback, returnThisIfUnchanged) {
         var nu = this.greedyClone();
         var del;
-        nu.editAll(function (k, v, i) {
+        nu.editAll((k, v, i) => {
             if (!callback(k, v, i))
                 return del = Delete;
         });
         if (!del && returnThisIfUnchanged)
             return this;
         return nu;
-    };
+    }
     /** Returns a copy of the tree with all values altered by a callback function. */
-    BTree.prototype.mapValues = function (callback) {
+    mapValues(callback) {
         var tmp = {};
         var nu = this.greedyClone();
-        nu.editAll(function (k, v, i) {
+        nu.editAll((k, v, i) => {
             return tmp.value = callback(v, k, i), tmp;
         });
         return nu;
-    };
-    BTree.prototype.reduce = function (callback, initialValue) {
-        var i = 0, p = initialValue;
+    }
+    reduce(callback, initialValue) {
+        let i = 0, p = initialValue;
         var it = this.entries(this.minKey(), ReusedArray), next;
         while (!(next = it.next()).done)
             p = callback(p, next.value, i++, this);
         return p;
-    };
+    }
     /////////////////////////////////////////////////////////////////////////////
     // Iterator methods /////////////////////////////////////////////////////////
     /** Returns an iterator that provides items in order (ascending order if
@@ -358,14 +330,14 @@ var BTree = /** @class */ (function () {
      *  @param reusedArray Optional array used repeatedly to store key-value
      *         pairs, to avoid creating a new array on every iteration.
      */
-    BTree.prototype.entries = function (lowestKey, reusedArray) {
+    entries(lowestKey, reusedArray) {
         var info = this.findPath(lowestKey);
         if (info === undefined)
             return iterator();
-        var nodequeue = info.nodequeue, nodeindex = info.nodeindex, leaf = info.leaf;
+        var { nodequeue, nodeindex, leaf } = info;
         var state = reusedArray !== undefined ? 1 : 0;
         var i = (lowestKey === undefined ? -1 : leaf.indexOf(lowestKey, 0, this._compare) - 1);
-        return iterator(function () {
+        return iterator(() => {
             jump: for (;;) {
                 switch (state) {
                     case 0:
@@ -402,7 +374,7 @@ var BTree = /** @class */ (function () {
                 }
             }
         });
-    };
+    }
     /** Returns an iterator that provides items in reversed order.
      *  @param highestKey Key at which to start iterating, or undefined to
      *         start at maxKey(). If the specified key doesn't exist then iteration
@@ -412,20 +384,20 @@ var BTree = /** @class */ (function () {
      *  @param skipHighest Iff this flag is true and the highestKey exists in the
      *         collection, the pair matching highestKey is skipped, not iterated.
      */
-    BTree.prototype.entriesReversed = function (highestKey, reusedArray, skipHighest) {
+    entriesReversed(highestKey, reusedArray, skipHighest) {
         if (highestKey === undefined) {
             highestKey = this.maxKey();
             skipHighest = undefined;
             if (highestKey === undefined)
                 return iterator(); // collection is empty
         }
-        var _a = this.findPath(highestKey) || this.findPath(this.maxKey()), nodequeue = _a.nodequeue, nodeindex = _a.nodeindex, leaf = _a.leaf;
+        var { nodequeue, nodeindex, leaf } = this.findPath(highestKey) || this.findPath(this.maxKey());
         check(!nodequeue[0] || leaf === nodequeue[0][nodeindex[0]], "wat!");
         var i = leaf.indexOf(highestKey, 0, this._compare);
         if (!skipHighest && i < leaf.keys.length && this._compare(leaf.keys[i], highestKey) <= 0)
             i++;
         var state = reusedArray !== undefined ? 1 : 0;
-        return iterator(function () {
+        return iterator(() => {
             jump: for (;;) {
                 switch (state) {
                     case 0:
@@ -462,7 +434,7 @@ var BTree = /** @class */ (function () {
                 }
             }
         });
-    };
+    }
     /* Used by entries() and entriesReversed() to prepare to start iterating.
      * It develops a "node queue" for each non-leaf level of the tree.
      * Levels are numbered "bottom-up" so that level 0 is a list of leaf
@@ -472,7 +444,7 @@ var BTree = /** @class */ (function () {
      * such that nodequeue[L-1] === nodequeue[L][nodeindex[L]].children.
      * (However inside this function the order is reversed.)
      */
-    BTree.prototype.findPath = function (key) {
+    findPath(key) {
         var nextnode = this._root;
         var nodequeue, nodeindex;
         if (nextnode.isLeaf) {
@@ -490,8 +462,8 @@ var BTree = /** @class */ (function () {
             nodequeue.reverse();
             nodeindex.reverse();
         }
-        return { nodequeue: nodequeue, nodeindex: nodeindex, leaf: nextnode };
-    };
+        return { nodequeue, nodeindex, leaf: nextnode };
+    }
     /**
      * Computes the differences between `this` and `other`.
      * For efficiency, the diff is returned via invocations of supplied handlers.
@@ -505,7 +477,7 @@ var BTree = /** @class */ (function () {
      * @param onlyOther Callback invoked for all keys only present in `other`.
      * @param different Callback invoked for all keys with differing values.
      */
-    BTree.prototype.diffAgainst = function (other, onlyThis, onlyOther, different) {
+    diffAgainst(other, onlyThis, onlyOther, different) {
         if (other._compare !== this._compare) {
             throw new Error("Tree comparators are not the same.");
         }
@@ -525,36 +497,36 @@ var BTree = /** @class */ (function () {
         //    - If either cursor points to a key/value pair:
         //      - If thisCursor === otherCursor and the values differ, it is a Different.
         //      - If thisCursor > otherCursor and otherCursor is at a key/value pair, it is an OnlyOther.
-        //      - If thisCursor < otherCursor and thisCursor is at a key/value pair, it is an OnlyThis as long as the most recent 
-        //        cursor step was *not* otherCursor advancing from a tie. The extra condition avoids erroneous OnlyOther calls 
+        //      - If thisCursor < otherCursor and thisCursor is at a key/value pair, it is an OnlyThis as long as the most recent
+        //        cursor step was *not* otherCursor advancing from a tie. The extra condition avoids erroneous OnlyOther calls
         //        that would occur due to otherCursor being the "leader".
         //    - Otherwise, if both cursors point to nodes, compare them. If they are equal by reference (shared), skip
         //      both cursors to the next node in the walk.
         // - Once one cursor has finished stepping, any remaining steps (if any) are taken and key/value pairs are logged
         //   as OnlyOther (if otherCursor is stepping) or OnlyThis (if thisCursor is stepping).
-        // This algorithm gives the critical guarantee that all locations (both nodes and key/value pairs) in both trees that 
+        // This algorithm gives the critical guarantee that all locations (both nodes and key/value pairs) in both trees that
         // are identical by value (and possibly by reference) will be visited *at the same time* by the cursors.
         // This removes the possibility of emitting incorrect diffs, as well as allowing for skipping shared nodes.
-        var _compare = this._compare;
-        var thisCursor = BTree.makeDiffCursor(this);
-        var otherCursor = BTree.makeDiffCursor(other);
+        const { _compare } = this;
+        const thisCursor = BTree.makeDiffCursor(this);
+        const otherCursor = BTree.makeDiffCursor(other);
         // It doesn't matter how thisSteppedLast is initialized.
         // Step order is only used when either cursor is at a leaf, and cursors always start at a node.
-        var thisSuccess = true, otherSuccess = true, prevCursorOrder = BTree.compare(thisCursor, otherCursor, _compare);
+        let thisSuccess = true, otherSuccess = true, prevCursorOrder = BTree.compare(thisCursor, otherCursor, _compare);
         while (thisSuccess && otherSuccess) {
-            var cursorOrder = BTree.compare(thisCursor, otherCursor, _compare);
-            var thisLeaf = thisCursor.leaf, thisInternalSpine = thisCursor.internalSpine, thisLevelIndices = thisCursor.levelIndices;
-            var otherLeaf = otherCursor.leaf, otherInternalSpine = otherCursor.internalSpine, otherLevelIndices = otherCursor.levelIndices;
+            const cursorOrder = BTree.compare(thisCursor, otherCursor, _compare);
+            const { leaf: thisLeaf, internalSpine: thisInternalSpine, levelIndices: thisLevelIndices } = thisCursor;
+            const { leaf: otherLeaf, internalSpine: otherInternalSpine, levelIndices: otherLevelIndices } = otherCursor;
             if (thisLeaf || otherLeaf) {
                 // If the cursors were at the same location last step, then there is no work to be done.
                 if (prevCursorOrder !== 0) {
                     if (cursorOrder === 0) {
                         if (thisLeaf && otherLeaf && different) {
                             // Equal keys, check for modifications
-                            var valThis = thisLeaf.values[thisLevelIndices[thisLevelIndices.length - 1]];
-                            var valOther = otherLeaf.values[otherLevelIndices[otherLevelIndices.length - 1]];
+                            const valThis = thisLeaf.values[thisLevelIndices[thisLevelIndices.length - 1]];
+                            const valOther = otherLeaf.values[otherLevelIndices[otherLevelIndices.length - 1]];
                             if (!Object.is(valThis, valOther)) {
-                                var result = different(thisCursor.currentKey, valThis, valOther);
+                                const result = different(thisCursor.currentKey, valThis, valOther);
                                 if (result && result.break)
                                     return result.break;
                             }
@@ -566,16 +538,16 @@ var BTree = /** @class */ (function () {
                         // 2. thisCursor stepped last and leapfrogged otherCursor
                         // Either of these cases is an "only other"
                         if (otherLeaf && onlyOther) {
-                            var otherVal = otherLeaf.values[otherLevelIndices[otherLevelIndices.length - 1]];
-                            var result = onlyOther(otherCursor.currentKey, otherVal);
+                            const otherVal = otherLeaf.values[otherLevelIndices[otherLevelIndices.length - 1]];
+                            const result = onlyOther(otherCursor.currentKey, otherVal);
                             if (result && result.break)
                                 return result.break;
                         }
                     }
                     else if (onlyThis) {
                         if (thisLeaf && prevCursorOrder !== 0) {
-                            var valThis = thisLeaf.values[thisLevelIndices[thisLevelIndices.length - 1]];
-                            var result = onlyThis(thisCursor.currentKey, valThis);
+                            const valThis = thisLeaf.values[thisLevelIndices[thisLevelIndices.length - 1]];
+                            const result = onlyThis(thisCursor.currentKey, valThis);
                             if (result && result.break)
                                 return result.break;
                         }
@@ -583,10 +555,10 @@ var BTree = /** @class */ (function () {
                 }
             }
             else if (!thisLeaf && !otherLeaf && cursorOrder === 0) {
-                var lastThis = thisInternalSpine.length - 1;
-                var lastOther = otherInternalSpine.length - 1;
-                var nodeThis = thisInternalSpine[lastThis][thisLevelIndices[lastThis]];
-                var nodeOther = otherInternalSpine[lastOther][otherLevelIndices[lastOther]];
+                const lastThis = thisInternalSpine.length - 1;
+                const lastOther = otherInternalSpine.length - 1;
+                const nodeThis = thisInternalSpine[lastThis][thisLevelIndices[lastThis]];
+                const nodeOther = otherInternalSpine[lastOther][otherLevelIndices[lastOther]];
                 if (nodeOther === nodeThis) {
                     prevCursorOrder = 0;
                     thisSuccess = BTree.step(thisCursor, true);
@@ -606,11 +578,11 @@ var BTree = /** @class */ (function () {
             return BTree.finishCursorWalk(thisCursor, otherCursor, _compare, onlyThis);
         if (otherSuccess && onlyOther)
             return BTree.finishCursorWalk(otherCursor, thisCursor, _compare, onlyOther);
-    };
+    }
     ///////////////////////////////////////////////////////////////////////////
     // Helper methods for diffAgainst /////////////////////////////////////////
-    BTree.finishCursorWalk = function (cursor, cursorFinished, compareKeys, callback) {
-        var compared = BTree.compare(cursor, cursorFinished, compareKeys);
+    static finishCursorWalk(cursor, cursorFinished, compareKeys, callback) {
+        const compared = BTree.compare(cursor, cursorFinished, compareKeys);
         if (compared === 0) {
             if (!BTree.step(cursor))
                 return undefined;
@@ -619,25 +591,25 @@ var BTree = /** @class */ (function () {
             check(false, "cursor walk terminated early");
         }
         return BTree.stepToEnd(cursor, callback);
-    };
-    BTree.stepToEnd = function (cursor, callback) {
-        var canStep = true;
+    }
+    static stepToEnd(cursor, callback) {
+        let canStep = true;
         while (canStep) {
-            var leaf = cursor.leaf, levelIndices = cursor.levelIndices, currentKey = cursor.currentKey;
+            const { leaf, levelIndices, currentKey } = cursor;
             if (leaf) {
-                var value = leaf.values[levelIndices[levelIndices.length - 1]];
-                var result = callback(currentKey, value);
+                const value = leaf.values[levelIndices[levelIndices.length - 1]];
+                const result = callback(currentKey, value);
                 if (result && result.break)
                     return result.break;
             }
             canStep = BTree.step(cursor);
         }
         return undefined;
-    };
-    BTree.makeDiffCursor = function (tree) {
-        var _root = tree._root, height = tree.height;
+    }
+    static makeDiffCursor(tree) {
+        const { _root, height } = tree;
         return { height: height, internalSpine: [[_root]], levelIndices: [0], leaf: undefined, currentKey: _root.maxKey() };
-    };
+    }
     /**
      * Advances the cursor to the next step in the walk of its tree.
      * Cursors are walked backwards in sort order, as this allows them to leverage maxKey() in order to be compared in O(1).
@@ -645,21 +617,21 @@ var BTree = /** @class */ (function () {
      * @param stepToNode If true, the cursor will be advanced to the next node (skipping values)
      * @returns true if the step was completed and false if the step would have caused the cursor to move beyond the end of the tree.
      */
-    BTree.step = function (cursor, stepToNode) {
-        var internalSpine = cursor.internalSpine, levelIndices = cursor.levelIndices, leaf = cursor.leaf;
+    static step(cursor, stepToNode) {
+        const { internalSpine, levelIndices, leaf } = cursor;
         if (stepToNode === true || leaf) {
-            var levelsLength = levelIndices.length;
+            const levelsLength = levelIndices.length;
             // Step to the next node only if:
             // - We are explicitly directed to via stepToNode, or
             // - There are no key/value pairs left to step to in this leaf
             if (stepToNode === true || levelIndices[levelsLength - 1] === 0) {
-                var spineLength = internalSpine.length;
+                const spineLength = internalSpine.length;
                 // Root is leaf
                 if (spineLength === 0)
                     return false;
                 // Walk back up the tree until we find a new subtree to descend into
-                var nodeLevelIndex = spineLength - 1;
-                var levelIndexWalkBack = nodeLevelIndex;
+                const nodeLevelIndex = spineLength - 1;
+                let levelIndexWalkBack = nodeLevelIndex;
                 while (levelIndexWalkBack >= 0) {
                     if (levelIndices[levelIndexWalkBack] > 0) {
                         if (levelIndexWalkBack < levelsLength - 1) {
@@ -681,40 +653,40 @@ var BTree = /** @class */ (function () {
             }
             else {
                 // Move to new leaf value
-                var valueIndex = --levelIndices[levelsLength - 1];
+                const valueIndex = --levelIndices[levelsLength - 1];
                 cursor.currentKey = leaf.keys[valueIndex];
                 return true;
             }
         }
         else { // Cursor does not point to a value in a leaf, so move downwards
-            var nextLevel = internalSpine.length;
-            var currentLevel = nextLevel - 1;
-            var node = internalSpine[currentLevel][levelIndices[currentLevel]];
+            const nextLevel = internalSpine.length;
+            const currentLevel = nextLevel - 1;
+            const node = internalSpine[currentLevel][levelIndices[currentLevel]];
             if (node.isLeaf) {
                 // Entering into a leaf. Set the cursor to point at the last key/value pair.
                 cursor.leaf = node;
-                var valueIndex = levelIndices[nextLevel] = node.values.length - 1;
+                const valueIndex = levelIndices[nextLevel] = node.values.length - 1;
                 cursor.currentKey = node.keys[valueIndex];
             }
             else {
-                var children = node.children;
+                const children = node.children;
                 internalSpine[nextLevel] = children;
-                var childIndex = children.length - 1;
+                const childIndex = children.length - 1;
                 levelIndices[nextLevel] = childIndex;
                 cursor.currentKey = children[childIndex].maxKey();
             }
             return true;
         }
-    };
+    }
     /**
      * Compares the two cursors. Returns a value indicating which cursor is ahead in a walk.
      * Note that cursors are advanced in reverse sorting order.
      */
-    BTree.compare = function (cursorA, cursorB, compareKeys) {
-        var heightA = cursorA.height, currentKeyA = cursorA.currentKey, levelIndicesA = cursorA.levelIndices;
-        var heightB = cursorB.height, currentKeyB = cursorB.currentKey, levelIndicesB = cursorB.levelIndices;
+    static compare(cursorA, cursorB, compareKeys) {
+        const { height: heightA, currentKey: currentKeyA, levelIndices: levelIndicesA } = cursorA;
+        const { height: heightB, currentKey: currentKeyB, levelIndices: levelIndicesB } = cursorB;
         // Reverse the comparison order, as cursors are advanced in reverse sorting order
-        var keyComparison = compareKeys(currentKeyB, currentKeyA);
+        const keyComparison = compareKeys(currentKeyB, currentKeyA);
         if (keyComparison !== 0) {
             return keyComparison;
         }
@@ -723,142 +695,137 @@ var BTree = /** @class */ (function () {
         // To accomplish this, a cursor that is on an internal node at depth D1 with maxKey X is considered "behind" a cursor on an
         // internal node at depth D2 with maxKey Y, when D1 < D2. Thus, always walking the cursor that is "behind" will allow the cursor
         // at shallower depth (but equal maxKey) to "catch up" and land on shared nodes.
-        var heightMin = heightA < heightB ? heightA : heightB;
-        var depthANormalized = levelIndicesA.length - (heightA - heightMin);
-        var depthBNormalized = levelIndicesB.length - (heightB - heightMin);
+        const heightMin = heightA < heightB ? heightA : heightB;
+        const depthANormalized = levelIndicesA.length - (heightA - heightMin);
+        const depthBNormalized = levelIndicesB.length - (heightB - heightMin);
         return depthANormalized - depthBNormalized;
-    };
+    }
     // End of helper methods for diffAgainst //////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////
     /** Returns a new iterator for iterating the keys of each pair in ascending order.
      *  @param firstKey: Minimum key to include in the output. */
-    BTree.prototype.keys = function (firstKey) {
+    keys(firstKey) {
         var it = this.entries(firstKey, ReusedArray);
-        return iterator(function () {
+        return iterator(() => {
             var n = it.next();
             if (n.value)
                 n.value = n.value[0];
             return n;
         });
-    };
+    }
     /** Returns a new iterator for iterating the values of each pair in order by key.
      *  @param firstKey: Minimum key whose associated value is included in the output. */
-    BTree.prototype.values = function (firstKey) {
+    values(firstKey) {
         var it = this.entries(firstKey, ReusedArray);
-        return iterator(function () {
+        return iterator(() => {
             var n = it.next();
             if (n.value)
                 n.value = n.value[1];
             return n;
         });
-    };
-    Object.defineProperty(BTree.prototype, "maxNodeSize", {
-        /////////////////////////////////////////////////////////////////////////////
-        // Additional methods ///////////////////////////////////////////////////////
-        /** Returns the maximum number of children/values before nodes will split. */
-        get: function () {
-            return this._maxNodeSize;
-        },
-        enumerable: false,
-        configurable: true
-    });
+    }
+    /////////////////////////////////////////////////////////////////////////////
+    // Additional methods ///////////////////////////////////////////////////////
+    /** Returns the maximum number of children/values before nodes will split. */
+    get maxNodeSize() {
+        return this._maxNodeSize;
+    }
     /** Gets the lowest key in the tree. Complexity: O(log size) */
-    BTree.prototype.minKey = function () { return this._root.minKey(); };
+    minKey() { return this._root.minKey(); }
     /** Gets the highest key in the tree. Complexity: O(1) */
-    BTree.prototype.maxKey = function () { return this._root.maxKey(); };
+    maxKey() { return this._root.maxKey(); }
     /** Quickly clones the tree by marking the root node as shared.
      *  Both copies remain editable. When you modify either copy, any
      *  nodes that are shared (or potentially shared) between the two
      *  copies are cloned so that the changes do not affect other copies.
      *  This is known as copy-on-write behavior, or "lazy copying". */
-    BTree.prototype.clone = function () {
+    clone() {
         this._root.isShared = true;
         var result = new BTree(undefined, this._compare, this._maxNodeSize);
         result._root = this._root;
         result._size = this._size;
         return result;
-    };
+    }
     /** Performs a greedy clone, immediately duplicating any nodes that are
      *  not currently marked as shared, in order to avoid marking any
      *  additional nodes as shared.
      *  @param force Clone all nodes, even shared ones.
      */
-    BTree.prototype.greedyClone = function (force) {
+    greedyClone(force) {
         var result = new BTree(undefined, this._compare, this._maxNodeSize);
         result._root = this._root.greedyClone(force);
         result._size = this._size;
         return result;
-    };
+    }
     /** Gets an array filled with the contents of the tree, sorted by key */
-    BTree.prototype.toArray = function (maxLength) {
-        if (maxLength === void 0) { maxLength = 0x7FFFFFFF; }
-        var min = this.minKey(), max = this.maxKey();
+    toArray(maxLength = 0x7FFFFFFF) {
+        let min = this.minKey(), max = this.maxKey();
         if (min !== undefined)
             return this.getRange(min, max, true, maxLength);
         return [];
-    };
+    }
     /** Gets an array of all keys, sorted */
-    BTree.prototype.keysArray = function () {
+    keysArray() {
         var results = [];
-        this._root.forRange(this.minKey(), this.maxKey(), true, false, this, 0, function (k, v) { results.push(k); });
+        this._root.forRange(this.minKey(), this.maxKey(), true, false, this, 0, (k, v) => { results.push(k); });
         return results;
-    };
+    }
     /** Gets an array of all values, sorted by key */
-    BTree.prototype.valuesArray = function () {
+    valuesArray() {
         var results = [];
-        this._root.forRange(this.minKey(), this.maxKey(), true, false, this, 0, function (k, v) { results.push(v); });
+        this._root.forRange(this.minKey(), this.maxKey(), true, false, this, 0, (k, v) => { results.push(v); });
         return results;
-    };
+    }
     /** Gets a string representing the tree's data based on toArray(). */
-    BTree.prototype.toString = function () {
+    toString() {
         return this.toArray().toString();
-    };
+    }
     /** Stores a key-value pair only if the key doesn't already exist in the tree.
      * @returns true if a new key was added
     */
-    BTree.prototype.setIfNotPresent = function (key, value) {
+    setIfNotPresent(key, value) {
         return this.set(key, value, false);
-    };
+    }
     /** Returns the next pair whose key is larger than the specified key (or undefined if there is none).
      * If key === undefined, this function returns the lowest pair.
      * @param key The key to search for.
      * @param reusedArray Optional array used repeatedly to store key-value pairs, to
      * avoid creating a new array on every iteration.
      */
-    BTree.prototype.nextHigherPair = function (key, reusedArray) {
+    nextHigherPair(key, reusedArray) {
         reusedArray = reusedArray || [];
         if (key === undefined) {
             return this._root.minPair(reusedArray);
         }
         return this._root.getPairOrNextHigher(key, this._compare, false, reusedArray);
-    };
+    }
     /** Returns the next key larger than the specified key, or undefined if there is none.
      *  Also, nextHigherKey(undefined) returns the lowest key.
      */
-    BTree.prototype.nextHigherKey = function (key) {
+    nextHigherKey(key) {
         var p = this.nextHigherPair(key, ReusedArray);
         return p && p[0];
-    };
+    }
     /** Returns the next pair whose key is smaller than the specified key (or undefined if there is none).
      *  If key === undefined, this function returns the highest pair.
      * @param key The key to search for.
      * @param reusedArray Optional array used repeatedly to store key-value pairs, to
      *        avoid creating a new array each time you call this method.
      */
-    BTree.prototype.nextLowerPair = function (key, reusedArray) {
+    nextLowerPair(key, reusedArray) {
         reusedArray = reusedArray || [];
         if (key === undefined) {
             return this._root.maxPair(reusedArray);
         }
         return this._root.getPairOrNextLower(key, this._compare, false, reusedArray);
-    };
+    }
     /** Returns the next key smaller than the specified key, or undefined if there is none.
      *  Also, nextLowerKey(undefined) returns the highest key.
      */
-    BTree.prototype.nextLowerKey = function (key) {
+    nextLowerKey(key) {
         var p = this.nextLowerPair(key, ReusedArray);
         return p && p[0];
-    };
+    }
     /** Returns the key-value pair associated with the supplied key if it exists
      *  or the pair associated with the next lower pair otherwise. If there is no
      *  next lower pair, undefined is returned.
@@ -866,9 +833,9 @@ var BTree = /** @class */ (function () {
      * @param reusedArray Optional array used repeatedly to store key-value pairs, to
      *        avoid creating a new array each time you call this method.
      * */
-    BTree.prototype.getPairOrNextLower = function (key, reusedArray) {
+    getPairOrNextLower(key, reusedArray) {
         return this._root.getPairOrNextLower(key, this._compare, true, reusedArray || []);
-    };
+    }
     /** Returns the key-value pair associated with the supplied key if it exists
      *  or the pair associated with the next lower pair otherwise. If there is no
      *  next lower pair, undefined is returned.
@@ -876,15 +843,15 @@ var BTree = /** @class */ (function () {
      * @param reusedArray Optional array used repeatedly to store key-value pairs, to
      *        avoid creating a new array each time you call this method.
      * */
-    BTree.prototype.getPairOrNextHigher = function (key, reusedArray) {
+    getPairOrNextHigher(key, reusedArray) {
         return this._root.getPairOrNextHigher(key, this._compare, true, reusedArray || []);
-    };
+    }
     /** Edits the value associated with a key in the tree, if it already exists.
      * @returns true if the key existed, false if not.
     */
-    BTree.prototype.changeIfPresent = function (key, value) {
-        return this.editRange(key, key, true, function (k, v) { return ({ value: value }); }) !== 0;
-    };
+    changeIfPresent(key, value) {
+        return this.editRange(key, key, true, (k, v) => ({ value })) !== 0;
+    }
     /**
      * Builds an array of pairs from the specified range of keys, sorted by key.
      * Each returned pair is also an array: pair[0] is the key, pair[1] is the value.
@@ -897,15 +864,14 @@ var BTree = /** @class */ (function () {
      *                  the array reaches this size.
      * @description Computational complexity: O(result.length + log size)
      */
-    BTree.prototype.getRange = function (low, high, includeHigh, maxLength) {
-        if (maxLength === void 0) { maxLength = 0x3FFFFFF; }
+    getRange(low, high, includeHigh, maxLength = 0x3FFFFFF) {
         var results = [];
-        this._root.forRange(low, high, includeHigh, false, this, 0, function (k, v) {
+        this._root.forRange(low, high, includeHigh, false, this, 0, (k, v) => {
             results.push([k, v]);
             return results.length > maxLength ? Break : undefined;
         });
         return results;
-    };
+    }
     /** Adds all pairs from a list of key-value pairs.
      * @param pairs Pairs to add to this tree. If there are duplicate keys,
      *        later pairs currently overwrite earlier ones (e.g. [[0,1],[0,7]]
@@ -915,13 +881,13 @@ var BTree = /** @class */ (function () {
      * @returns The number of pairs added to the collection.
      * @description Computational complexity: O(pairs.length * log(size + pairs.length))
      */
-    BTree.prototype.setPairs = function (pairs, overwrite) {
+    setPairs(pairs, overwrite) {
         var added = 0;
         for (var i = 0; i < pairs.length; i++)
             if (this.set(pairs[i][0], pairs[i][1], overwrite))
                 added++;
         return added;
-    };
+    }
     /**
      * Scans the specified range of keys, in ascending order by key.
      * Note: the callback `onFound` must not insert or remove items in the
@@ -939,10 +905,10 @@ var BTree = /** @class */ (function () {
      *        `{break:R}` to stop early.
      * @description Computational complexity: O(number of items scanned + log size)
      */
-    BTree.prototype.forRange = function (low, high, includeHigh, onFound, initialCounter) {
+    forRange(low, high, includeHigh, onFound, initialCounter) {
         var r = this._root.forRange(low, high, includeHigh, false, this, initialCounter || 0, onFound);
         return typeof r === "number" ? r : r.break;
-    };
+    }
     /**
      * Scans and potentially modifies values for a subsequence of keys.
      * Note: the callback `onFound` should ideally be a pure function.
@@ -972,7 +938,7 @@ var BTree = /** @class */ (function () {
      *   nodes are copied before `onFound` is called. This takes O(n) time
      *   where n is proportional to the amount of shared data scanned.
      */
-    BTree.prototype.editRange = function (low, high, includeHigh, onFound, initialCounter) {
+    editRange(low, high, includeHigh, onFound, initialCounter) {
         var root = this._root;
         if (root.isShared)
             this._root = root = root.clone();
@@ -981,7 +947,7 @@ var BTree = /** @class */ (function () {
             return typeof r === "number" ? r : r.break;
         }
         finally {
-            var isShared = void 0;
+            let isShared;
             while (root.keys.length <= 1 && !root.isLeaf) {
                 isShared || (isShared = root.isShared);
                 this._root = root = root.keys.length === 0 ? EmptyLeaf :
@@ -992,11 +958,11 @@ var BTree = /** @class */ (function () {
                 root.isShared = true;
             }
         }
-    };
+    }
     /** Same as `editRange` except that the callback is called for all pairs. */
-    BTree.prototype.editAll = function (onFound, initialCounter) {
+    editAll(onFound, initialCounter) {
         return this.editRange(this.minKey(), this.maxKey(), true, onFound, initialCounter);
-    };
+    }
     /**
      * Removes a range of key-value pairs from the B+ tree.
      * @param low The first key scanned will be greater than or equal to `low`.
@@ -1005,47 +971,43 @@ var BTree = /** @class */ (function () {
      * @returns The number of key-value pairs that were deleted.
      * @description Computational complexity: O(log size + number of items deleted)
      */
-    BTree.prototype.deleteRange = function (low, high, includeHigh) {
+    deleteRange(low, high, includeHigh) {
         return this.editRange(low, high, includeHigh, DeleteRange);
-    };
+    }
     /** Deletes a series of keys from the collection. */
-    BTree.prototype.deleteKeys = function (keys) {
+    deleteKeys(keys) {
         for (var i = 0, r = 0; i < keys.length; i++)
             if (this.delete(keys[i]))
                 r++;
         return r;
-    };
-    Object.defineProperty(BTree.prototype, "height", {
-        /** Gets the height of the tree: the number of internal nodes between the
-         *  BTree object and its leaf nodes (zero if there are no internal nodes). */
-        get: function () {
-            var node = this._root;
-            var height = -1;
-            while (node) {
-                height++;
-                node = node.isLeaf ? undefined : node.children[0];
-            }
-            return height;
-        },
-        enumerable: false,
-        configurable: true
-    });
+    }
+    /** Gets the height of the tree: the number of internal nodes between the
+     *  BTree object and its leaf nodes (zero if there are no internal nodes). */
+    get height() {
+        let node = this._root;
+        let height = -1;
+        while (node) {
+            height++;
+            node = node.isLeaf ? undefined : node.children[0];
+        }
+        return height;
+    }
     /** Makes the object read-only to ensure it is not accidentally modified.
      *  Freezing does not have to be permanent; unfreeze() reverses the effect.
      *  This is accomplished by replacing mutator functions with a function
      *  that throws an Error. Compared to using a property (e.g. this.isFrozen)
      *  this implementation gives better performance in non-frozen BTrees.
      */
-    BTree.prototype.freeze = function () {
+    freeze() {
         var t = this;
-        // Note: all other mutators ultimately call set() or editRange() 
+        // Note: all other mutators ultimately call set() or editRange()
         //       so we don't need to override those others.
         t.clear = t.set = t.editRange = function () {
             throw new Error("Attempted to modify a frozen BTree");
         };
-    };
+    }
     /** Ensures mutations are allowed, reversing the effect of freeze(). */
-    BTree.prototype.unfreeze = function () {
+    unfreeze() {
         // @ts-ignore "The operand of a 'delete' operator must be optional."
         //            (wrong: delete does not affect the prototype.)
         delete this.clear;
@@ -1053,27 +1015,22 @@ var BTree = /** @class */ (function () {
         delete this.set;
         // @ts-ignore
         delete this.editRange;
-    };
-    Object.defineProperty(BTree.prototype, "isFrozen", {
-        /** Returns true if the tree appears to be frozen. */
-        get: function () {
-            return this.hasOwnProperty('editRange');
-        },
-        enumerable: false,
-        configurable: true
-    });
+    }
+    /** Returns true if the tree appears to be frozen. */
+    get isFrozen() {
+        return this.hasOwnProperty('editRange');
+    }
     /** Scans the tree for signs of serious bugs (e.g. this.size doesn't match
      *  number of elements, internal nodes not caching max element properly...)
      *  Computational complexity: O(number of nodes), i.e. O(size). This method
      *  skips the most expensive test - whether all keys are sorted - but it
      *  does check that maxKey() of the children of internal nodes are sorted. */
-    BTree.prototype.checkValid = function () {
+    checkValid() {
         var size = this._root.checkValid(0, this, 0);
         check(size === this.size, "size mismatch: counted ", size, "but stored", this.size);
-    };
-    return BTree;
-}());
-exports.default = BTree;
+    }
+}
+exports.BTree = BTree;
 /** A TypeScript helper function that simply returns its argument, typed as
  *  `ISortedSet<K>` if the BTree implements it, as it does if `V extends undefined`.
  *  If `V` cannot be `undefined`, it returns `unknown` instead. Or at least, that
@@ -1088,35 +1045,29 @@ if (Symbol && Symbol.iterator) // iterator is equivalent to entries()
 BTree.prototype.where = BTree.prototype.filter;
 BTree.prototype.setRange = BTree.prototype.setPairs;
 BTree.prototype.add = BTree.prototype.set; // for compatibility with ISetSink<K>
-function iterator(next) {
-    if (next === void 0) { next = (function () { return ({ done: true, value: undefined }); }); }
-    var result = { next: next };
+function iterator(next = (() => ({ done: true, value: undefined }))) {
+    var result = { next };
     if (Symbol && Symbol.iterator)
         result[Symbol.iterator] = function () { return this; };
     return result;
 }
 /** Leaf node / base class. **************************************************/
-var BNode = /** @class */ (function () {
-    function BNode(keys, values) {
-        if (keys === void 0) { keys = []; }
+class BNode {
+    get isLeaf() { return this.children === undefined; }
+    constructor(keys = [], values) {
         this.keys = keys;
         this.values = values || undefVals;
         this.isShared = undefined;
     }
-    Object.defineProperty(BNode.prototype, "isLeaf", {
-        get: function () { return this.children === undefined; },
-        enumerable: false,
-        configurable: true
-    });
     ///////////////////////////////////////////////////////////////////////////
     // Shared methods /////////////////////////////////////////////////////////
-    BNode.prototype.maxKey = function () {
+    maxKey() {
         return this.keys[this.keys.length - 1];
-    };
+    }
     // If key not found, returns i^failXor where i is the insertion index.
     // Callers that don't care whether there was a match will set failXor=0.
-    BNode.prototype.indexOf = function (key, failXor, cmp) {
-        var keys = this.keys;
+    indexOf(key, failXor, cmp) {
+        const keys = this.keys;
         var lo = 0, hi = keys.length, mid = hi >> 1;
         while (lo < hi) {
             var c = cmp(keys[mid], key);
@@ -1180,73 +1131,73 @@ var BNode = /** @class */ (function () {
             throw new Error("BTree: NaN was used as a key");
         }
         return c === 0 ? i : i ^ failXor;*/
-    };
+    }
     /////////////////////////////////////////////////////////////////////////////
     // Leaf Node: misc //////////////////////////////////////////////////////////
-    BNode.prototype.minKey = function () {
+    minKey() {
         return this.keys[0];
-    };
-    BNode.prototype.minPair = function (reusedArray) {
+    }
+    minPair(reusedArray) {
         if (this.keys.length === 0)
             return undefined;
         reusedArray[0] = this.keys[0];
         reusedArray[1] = this.values[0];
         return reusedArray;
-    };
-    BNode.prototype.maxPair = function (reusedArray) {
+    }
+    maxPair(reusedArray) {
         if (this.keys.length === 0)
             return undefined;
-        var lastIndex = this.keys.length - 1;
+        const lastIndex = this.keys.length - 1;
         reusedArray[0] = this.keys[lastIndex];
         reusedArray[1] = this.values[lastIndex];
         return reusedArray;
-    };
-    BNode.prototype.clone = function () {
+    }
+    clone() {
         var v = this.values;
         return new BNode(this.keys.slice(0), v === undefVals ? v : v.slice(0));
-    };
-    BNode.prototype.greedyClone = function (force) {
+    }
+    greedyClone(force) {
         return this.isShared && !force ? this : this.clone();
-    };
-    BNode.prototype.get = function (key, defaultValue, tree) {
+    }
+    get(key, defaultValue, tree) {
         var i = this.indexOf(key, -1, tree._compare);
         return i < 0 ? defaultValue : this.values[i];
-    };
-    BNode.prototype.getPairOrNextLower = function (key, compare, inclusive, reusedArray) {
+    }
+    getPairOrNextLower(key, compare, inclusive, reusedArray) {
         var i = this.indexOf(key, -1, compare);
-        var indexOrLower = i < 0 ? ~i - 1 : (inclusive ? i : i - 1);
+        const indexOrLower = i < 0 ? ~i - 1 : (inclusive ? i : i - 1);
         if (indexOrLower >= 0) {
             reusedArray[0] = this.keys[indexOrLower];
             reusedArray[1] = this.values[indexOrLower];
             return reusedArray;
         }
         return undefined;
-    };
-    BNode.prototype.getPairOrNextHigher = function (key, compare, inclusive, reusedArray) {
+    }
+    getPairOrNextHigher(key, compare, inclusive, reusedArray) {
         var i = this.indexOf(key, -1, compare);
-        var indexOrLower = i < 0 ? ~i : (inclusive ? i : i + 1);
-        var keys = this.keys;
+        const indexOrLower = i < 0 ? ~i : (inclusive ? i : i + 1);
+        const keys = this.keys;
         if (indexOrLower < keys.length) {
             reusedArray[0] = keys[indexOrLower];
             reusedArray[1] = this.values[indexOrLower];
             return reusedArray;
         }
         return undefined;
-    };
-    BNode.prototype.checkValid = function (depth, tree, baseIndex) {
+    }
+    checkValid(depth, tree, baseIndex) {
         var kL = this.keys.length, vL = this.values.length;
         check(this.values === undefVals ? kL <= vL : kL === vL, "keys/values length mismatch: depth", depth, "with lengths", kL, vL, "and baseIndex", baseIndex);
         // Note: we don't check for "node too small" because sometimes a node
-        // can legitimately have size 1. This occurs if there is a batch 
+        // can legitimately have size 1. This occurs if there is a batch
         // deletion, leaving a node of size 1, and the siblings are full so
         // it can't be merged with adjacent nodes. However, the parent will
         // verify that the average node size is at least half of the maximum.
         check(depth == 0 || kL > 0, "empty leaf at depth", depth, "and baseIndex", baseIndex);
         return kL;
-    };
+    }
     /////////////////////////////////////////////////////////////////////////////
     // Leaf Node: set & node splitting //////////////////////////////////////////
-    BNode.prototype.set = function (key, value, overwrite, tree) {
+    set(key, value, overwrite, tree) {
         var i = this.indexOf(key, -1, tree._compare);
         if (i < 0) {
             // key does not exist yet
@@ -1277,13 +1228,13 @@ var BNode = /** @class */ (function () {
             }
             return false;
         }
-    };
-    BNode.prototype.reifyValues = function () {
+    }
+    reifyValues() {
         if (this.values === undefVals)
             return this.values = this.values.slice(0, this.keys.length);
         return this.values;
-    };
-    BNode.prototype.insertInLeaf = function (i, key, value, tree) {
+    }
+    insertInLeaf(i, key, value, tree) {
         this.keys.splice(i, 0, key);
         if (this.values === undefVals) {
             while (undefVals.length < tree._maxNodeSize)
@@ -1297,8 +1248,8 @@ var BNode = /** @class */ (function () {
         }
         this.values.splice(i, 0, value);
         return true;
-    };
-    BNode.prototype.takeFromRight = function (rhs) {
+    }
+    takeFromRight(rhs) {
         // Reminder: parent node must update its copy of key for this node
         // assert: neither node is shared
         // assert rhs.keys.length > (maxNodeSize/2 && this.keys.length<maxNodeSize)
@@ -1312,8 +1263,8 @@ var BNode = /** @class */ (function () {
             v.push(rhs.values.shift());
         }
         this.keys.push(rhs.keys.shift());
-    };
-    BNode.prototype.takeFromLeft = function (lhs) {
+    }
+    takeFromLeft(lhs) {
         // Reminder: parent node must update its copy of key for this node
         // assert: neither node is shared
         // assert rhs.keys.length > (maxNodeSize/2 && this.keys.length<maxNodeSize)
@@ -1327,16 +1278,16 @@ var BNode = /** @class */ (function () {
             v.unshift(lhs.values.pop());
         }
         this.keys.unshift(lhs.keys.pop());
-    };
-    BNode.prototype.splitOffRightSide = function () {
+    }
+    splitOffRightSide() {
         // Reminder: parent node must update its copy of key for this node
         var half = this.keys.length >> 1, keys = this.keys.splice(half);
         var values = this.values === undefVals ? undefVals : this.values.splice(half);
         return new BNode(keys, values);
-    };
+    }
     /////////////////////////////////////////////////////////////////////////////
     // Leaf Node: scanning & deletions //////////////////////////////////////////
-    BNode.prototype.forRange = function (low, high, includeHigh, editMode, tree, count, onFound) {
+    forRange(low, high, includeHigh, editMode, tree, count, onFound) {
         var cmp = tree._compare;
         var iLow, iHigh;
         if (high === low) {
@@ -1383,9 +1334,9 @@ var BNode = /** @class */ (function () {
         else
             count += iHigh - iLow;
         return count;
-    };
+    }
     /** Adds entire contents of right-hand sibling (rhs is left unchanged) */
-    BNode.prototype.mergeSibling = function (rhs, _) {
+    mergeSibling(rhs, _) {
         this.keys.push.apply(this.keys, rhs.keys);
         if (this.values === undefVals) {
             if (rhs.values === undefVals)
@@ -1393,79 +1344,75 @@ var BNode = /** @class */ (function () {
             this.values = this.values.slice(0, this.keys.length);
         }
         this.values.push.apply(this.values, rhs.reifyValues());
-    };
-    return BNode;
-}());
+    }
+}
 /** Internal node (non-leaf node) ********************************************/
-var BNodeInternal = /** @class */ (function (_super) {
-    __extends(BNodeInternal, _super);
+class BNodeInternal extends BNode {
     /**
      * This does not mark `children` as shared, so it is the responsibility of the caller
      * to ensure children are either marked shared, or aren't included in another tree.
      */
-    function BNodeInternal(children, keys) {
-        var _this = this;
+    constructor(children, keys) {
         if (!keys) {
             keys = [];
             for (var i = 0; i < children.length; i++)
                 keys[i] = children[i].maxKey();
         }
-        _this = _super.call(this, keys) || this;
-        _this.children = children;
-        return _this;
+        super(keys);
+        this.children = children;
     }
-    BNodeInternal.prototype.clone = function () {
+    clone() {
         var children = this.children.slice(0);
         for (var i = 0; i < children.length; i++)
             children[i].isShared = true;
         return new BNodeInternal(children, this.keys.slice(0));
-    };
-    BNodeInternal.prototype.greedyClone = function (force) {
+    }
+    greedyClone(force) {
         if (this.isShared && !force)
             return this;
         var nu = new BNodeInternal(this.children.slice(0), this.keys.slice(0));
         for (var i = 0; i < nu.children.length; i++)
             nu.children[i] = nu.children[i].greedyClone(force);
         return nu;
-    };
-    BNodeInternal.prototype.minKey = function () {
+    }
+    minKey() {
         return this.children[0].minKey();
-    };
-    BNodeInternal.prototype.minPair = function (reusedArray) {
+    }
+    minPair(reusedArray) {
         return this.children[0].minPair(reusedArray);
-    };
-    BNodeInternal.prototype.maxPair = function (reusedArray) {
+    }
+    maxPair(reusedArray) {
         return this.children[this.children.length - 1].maxPair(reusedArray);
-    };
-    BNodeInternal.prototype.get = function (key, defaultValue, tree) {
+    }
+    get(key, defaultValue, tree) {
         var i = this.indexOf(key, 0, tree._compare), children = this.children;
         return i < children.length ? children[i].get(key, defaultValue, tree) : undefined;
-    };
-    BNodeInternal.prototype.getPairOrNextLower = function (key, compare, inclusive, reusedArray) {
+    }
+    getPairOrNextLower(key, compare, inclusive, reusedArray) {
         var i = this.indexOf(key, 0, compare), children = this.children;
         if (i >= children.length)
             return this.maxPair(reusedArray);
-        var result = children[i].getPairOrNextLower(key, compare, inclusive, reusedArray);
+        const result = children[i].getPairOrNextLower(key, compare, inclusive, reusedArray);
         if (result === undefined && i > 0) {
             return children[i - 1].maxPair(reusedArray);
         }
         return result;
-    };
-    BNodeInternal.prototype.getPairOrNextHigher = function (key, compare, inclusive, reusedArray) {
+    }
+    getPairOrNextHigher(key, compare, inclusive, reusedArray) {
         var i = this.indexOf(key, 0, compare), children = this.children, length = children.length;
         if (i >= length)
             return undefined;
-        var result = children[i].getPairOrNextHigher(key, compare, inclusive, reusedArray);
+        const result = children[i].getPairOrNextHigher(key, compare, inclusive, reusedArray);
         if (result === undefined && i < length - 1) {
             return children[i + 1].minPair(reusedArray);
         }
         return result;
-    };
-    BNodeInternal.prototype.checkValid = function (depth, tree, baseIndex) {
-        var kL = this.keys.length, cL = this.children.length;
+    }
+    checkValid(depth, tree, baseIndex) {
+        let kL = this.keys.length, cL = this.children.length;
         check(kL === cL, "keys/children length mismatch: depth", depth, "lengths", kL, cL, "baseIndex", baseIndex);
         check(kL > 1 || depth > 0, "internal node has length", kL, "at depth", depth, "baseIndex", baseIndex);
-        var size = 0, c = this.children, k = this.keys, childSize = 0;
+        let size = 0, c = this.children, k = this.keys, childSize = 0;
         for (var i = 0; i < cL; i++) {
             size += c[i].checkValid(depth + 1, tree, baseIndex + size);
             childSize += c[i].keys.length;
@@ -1478,14 +1425,14 @@ var BNodeInternal = /** @class */ (function (_super) {
         }
         // 2020/08: BTree doesn't always avoid grossly undersized nodes,
         // but AFAIK such nodes are pretty harmless, so accept them.
-        var toofew = childSize === 0; // childSize < (tree.maxNodeSize >> 1)*cL;
+        let toofew = childSize === 0; // childSize < (tree.maxNodeSize >> 1)*cL;
         if (toofew || childSize > tree.maxNodeSize * cL)
             check(false, toofew ? "too few" : "too many", "children (", childSize, size, ") at depth", depth, "maxNodeSize:", tree.maxNodeSize, "children.length:", cL, "baseIndex:", baseIndex);
         return size;
-    };
+    }
     /////////////////////////////////////////////////////////////////////////////
     // Internal Node: set & node splitting //////////////////////////////////////
-    BNodeInternal.prototype.set = function (key, value, overwrite, tree) {
+    set(key, value, overwrite, tree) {
         var c = this.children, max = tree._maxNodeSize, cmp = tree._compare;
         var i = Math.min(this.indexOf(key, 0, cmp), c.length - 1), child = c[i];
         if (child.isShared)
@@ -1529,45 +1476,45 @@ var BNodeInternal = /** @class */ (function (_super) {
             target.insert(i + 1, result);
             return newRightSibling;
         }
-    };
+    }
     /**
      * Inserts `child` at index `i`.
      * This does not mark `child` as shared, so it is the responsibility of the caller
      * to ensure that either child is marked shared, or it is not included in another tree.
      */
-    BNodeInternal.prototype.insert = function (i, child) {
+    insert(i, child) {
         this.children.splice(i, 0, child);
         this.keys.splice(i, 0, child.maxKey());
-    };
+    }
     /**
      * Split this node.
      * Modifies this to remove the second half of the items, returning a separate node containing them.
      */
-    BNodeInternal.prototype.splitOffRightSide = function () {
+    splitOffRightSide() {
         // assert !this.isShared;
         var half = this.children.length >> 1;
         return new BNodeInternal(this.children.splice(half), this.keys.splice(half));
-    };
-    BNodeInternal.prototype.takeFromRight = function (rhs) {
+    }
+    takeFromRight(rhs) {
         // Reminder: parent node must update its copy of key for this node
         // assert: neither node is shared
         // assert rhs.keys.length > (maxNodeSize/2 && this.keys.length<maxNodeSize)
         this.keys.push(rhs.keys.shift());
         this.children.push(rhs.children.shift());
-    };
-    BNodeInternal.prototype.takeFromLeft = function (lhs) {
+    }
+    takeFromLeft(lhs) {
         // Reminder: parent node must update its copy of key for this node
         // assert: neither node is shared
         // assert rhs.keys.length > (maxNodeSize/2 && this.keys.length<maxNodeSize)
         this.keys.unshift(lhs.keys.pop());
         this.children.unshift(lhs.children.pop());
-    };
+    }
     /////////////////////////////////////////////////////////////////////////////
     // Internal Node: scanning & deletions //////////////////////////////////////
-    // Note: `count` is the next value of the third argument to `onFound`. 
+    // Note: `count` is the next value of the third argument to `onFound`.
     //       A leaf node's `forRange` function returns a new value for this counter,
     //       unless the operation is to stop early.
-    BNodeInternal.prototype.forRange = function (low, high, includeHigh, editMode, tree, count, onFound) {
+    forRange(low, high, includeHigh, editMode, tree, count, onFound) {
         var cmp = tree._compare;
         var keys = this.keys, children = this.children;
         var iLow = this.indexOf(low, 0, cmp), i = iLow;
@@ -1616,9 +1563,9 @@ var BNodeInternal = /** @class */ (function (_super) {
             }
         }
         return count;
-    };
+    }
     /** Merges child i with child i+1 if their combined size is not too large */
-    BNodeInternal.prototype.tryMerge = function (i, maxSize) {
+    tryMerge(i, maxSize) {
         var children = this.children;
         if (i >= 0 && i + 1 < children.length) {
             if (children[i].keys.length + children[i + 1].keys.length <= maxSize) {
@@ -1632,17 +1579,17 @@ var BNodeInternal = /** @class */ (function (_super) {
             }
         }
         return false;
-    };
+    }
     /**
      * Move children from `rhs` into this.
      * `rhs` must be part of this tree, and be removed from it after this call
      * (otherwise isShared for its children could be incorrect).
      */
-    BNodeInternal.prototype.mergeSibling = function (rhs, maxNodeSize) {
+    mergeSibling(rhs, maxNodeSize) {
         // assert !this.isShared;
         var oldLength = this.keys.length;
         this.keys.push.apply(this.keys, rhs.keys);
-        var rhsChildren = rhs.children;
+        const rhsChildren = rhs.children;
         this.children.push.apply(this.children, rhsChildren);
         if (rhs.isShared && !this.isShared) {
             // All children of a shared node are implicitly shared, and since their new
@@ -1654,9 +1601,8 @@ var BNodeInternal = /** @class */ (function (_super) {
         // they may need to be merged too (but only the oldLength-1 and its
         // right sibling should need this).
         this.tryMerge(oldLength - 1, maxNodeSize);
-    };
-    return BNodeInternal;
-}(BNode));
+    }
+}
 // Optimization: this array of `undefined`s is used instead of a normal
 // array of values in nodes where `undefined` is the only value.
 // Its length is extended to max node size on first use; since it can
@@ -1669,24 +1615,20 @@ var BNodeInternal = /** @class */ (function (_super) {
 // Reading outside the bounds of an array is relatively slow because it
 // has the side effect of scanning the prototype chain.
 var undefVals = [];
-var Delete = { delete: true }, DeleteRange = function () { return Delete; };
-var Break = { break: true };
-var EmptyLeaf = (function () {
+const Delete = { delete: true }, DeleteRange = () => Delete;
+const Break = { break: true };
+const EmptyLeaf = (function () {
     var n = new BNode();
     n.isShared = true;
     return n;
 })();
-var EmptyArray = [];
-var ReusedArray = []; // assumed thread-local
-function check(fact) {
-    var args = [];
-    for (var _i = 1; _i < arguments.length; _i++) {
-        args[_i - 1] = arguments[_i];
-    }
+const EmptyArray = [];
+const ReusedArray = []; // assumed thread-local
+function check(fact, ...args) {
     if (!fact) {
         args.unshift('B+ tree'); // at beginning of message
         throw new Error(args.join(' '));
     }
 }
 /** A BTree frozen in the empty state. */
-exports.EmptyBTree = (function () { var t = new BTree(); t.freeze(); return t; })();
+exports.EmptyBTree = (() => { let t = new BTree(); t.freeze(); return t; })();

--- a/b+tree.ts
+++ b/b+tree.ts
@@ -39,19 +39,19 @@ export type DefaultComparable = number | string | Date | boolean | null | undefi
 
 /**
  * Compares DefaultComparables to form a strict partial ordering.
- * 
+ *
  * Handles +/-0 and NaN like Map: NaN is equal to NaN, and -0 is equal to +0.
- * 
+ *
  * Arrays are compared using '<' and '>', which may cause unexpected equality:
  * for example [1] will be considered equal to ['1'].
- * 
+ *
  * Two objects with equal valueOf compare the same, but compare unequal to
  * primitives that have the same value.
  */
 export function defaultComparator(a: DefaultComparable, b: DefaultComparable): number {
   // Special case finite numbers first for performance.
   // Note that the trick of using 'a - b' and checking for NaN to detect non-numbers
-  // does not work if the strings are numeric (ex: "5"). This would leading most 
+  // does not work if the strings are numeric (ex: "5"). This would leading most
   // comparison functions using that approach to fail to have transitivity.
   if (Number.isFinite(a as any) && Number.isFinite(b as any)) {
     return a as number - (b as number);
@@ -82,7 +82,7 @@ export function defaultComparator(a: DefaultComparable, b: DefaultComparable): n
     }
   }
 
-  // a and b are now the same type, and will be a number, string or array 
+  // a and b are now the same type, and will be a number, string or array
   // (which we assume holds numbers or strings), or something unsupported.
   if (a! < b!) return -1;
   if (a! > b!) return 1;
@@ -98,15 +98,15 @@ export function defaultComparator(a: DefaultComparable, b: DefaultComparable): n
 };
 
 /**
- * Compares items using the < and > operators. This function is probably slightly 
- * faster than the defaultComparator for Dates and strings, but has not been benchmarked. 
- * Unlike defaultComparator, this comparator doesn't support mixed types correctly, 
+ * Compares items using the < and > operators. This function is probably slightly
+ * faster than the defaultComparator for Dates and strings, but has not been benchmarked.
+ * Unlike defaultComparator, this comparator doesn't support mixed types correctly,
  * i.e. use it with `BTree<string>` or `BTree<number>` but not `BTree<string|number>`.
- * 
+ *
  * NaN is not supported.
- * 
- * Note: null is treated like 0 when compared with numbers or Date, but in general 
- *   null is not ordered with respect to strings (neither greater nor less), and 
+ *
+ * Note: null is treated like 0 when compared with numbers or Date, but in general
+ *   null is not ordered with respect to strings (neither greater nor less), and
  *   undefined is not ordered with other types.
  */
 export function simpleComparator(a: string, b:string): number;
@@ -118,38 +118,38 @@ export function simpleComparator(a: any, b: any): number {
 };
 
 /**
- * A reasonably fast collection of key-value pairs with a powerful API. 
+ * A reasonably fast collection of key-value pairs with a powerful API.
  * Largely compatible with the standard Map. BTree is a B+ tree data structure,
  * so the collection is sorted by key.
- * 
+ *
  * B+ trees tend to use memory more efficiently than hashtables such as the
- * standard Map, especially when the collection contains a large number of 
- * items. However, maintaining the sort order makes them modestly slower: 
+ * standard Map, especially when the collection contains a large number of
+ * items. However, maintaining the sort order makes them modestly slower:
  * O(log size) rather than O(1). This B+ tree implementation supports O(1)
  * fast cloning. It also supports freeze(), which can be used to ensure that
  * a BTree is not changed accidentally.
- * 
+ *
  * Confusingly, the ES6 Map.forEach(c) method calls c(value,key) instead of
  * c(key,value), in contrast to other methods such as set() and entries()
- * which put the key first. I can only assume that the order was reversed on 
+ * which put the key first. I can only assume that the order was reversed on
  * the theory that users would usually want to examine values and ignore keys.
- * BTree's forEach() therefore works the same way, but a second method 
+ * BTree's forEach() therefore works the same way, but a second method
  * `.forEachPair((key,value)=>{...})` is provided which sends you the key
- * first and the value second; this method is slightly faster because it is 
+ * first and the value second; this method is slightly faster because it is
  * the "native" for-each method for this class.
- * 
- * Out of the box, BTree supports keys that are numbers, strings, arrays of 
- * numbers/strings, Date, and objects that have a valueOf() method returning a 
+ *
+ * Out of the box, BTree supports keys that are numbers, strings, arrays of
+ * numbers/strings, Date, and objects that have a valueOf() method returning a
  * number or string. Other data types, such as arrays of Date or custom
- * objects, require a custom comparator, which you must pass as the second 
- * argument to the constructor (the first argument is an optional list of 
+ * objects, require a custom comparator, which you must pass as the second
+ * argument to the constructor (the first argument is an optional list of
  * initial items). Symbols cannot be used as keys because they are unordered
  * (one Symbol is never "greater" or "less" than another).
- * 
+ *
  * @example
  * Given a {name: string, age: number} object, you can create a tree sorted by
  * name and then by age like this:
- *   
+ *
  *     var tree = new BTree(undefined, (a, b) => {
  *       if (a.name > b.name)
  *         return 1; // Return a number >0 when a > b
@@ -158,30 +158,30 @@ export function simpleComparator(a: any, b: any): number {
  *       else // names are equal (or incomparable)
  *         return a.age - b.age; // Return >0 when a.age > b.age
  *     });
- * 
+ *
  *     tree.set({name:"Bill", age:17}, "happy");
  *     tree.set({name:"Fran", age:40}, "busy & stressed");
  *     tree.set({name:"Bill", age:55}, "recently laid off");
  *     tree.forEachPair((k, v) => {
  *       console.log(`Name: ${k.name} Age: ${k.age} Status: ${v}`);
  *     });
- * 
+ *
  * @description
  * The "range" methods (`forEach, forRange, editRange`) will return the number
  * of elements that were scanned. In addition, the callback can return {break:R}
  * to stop early and return R from the outer function.
- * 
+ *
  * - TODO: Test performance of preallocating values array at max size
  * - TODO: Add fast initialization when a sorted array is provided to constructor
- * 
+ *
  * For more documentation see https://github.com/qwertie/btree-typescript
  *
- * Are you a C# developer? You might like the similar data structures I made for C#: 
+ * Are you a C# developer? You might like the similar data structures I made for C#:
  * BDictionary, BList, etc. See http://core.loyc.net/collections/
- * 
+ *
  * @author David Piepgrass
  */
-export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap<K,V>
+export class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap<K,V>
 {
   private _root: BNode<K, V> = EmptyLeaf as BNode<K,V>;
   _size: number = 0;
@@ -192,7 +192,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
    * @returns a negative value if a < b, 0 if a === b and a positive value if a > b
    */
   _compare: (a:K, b:K) => number;
-  
+
   /**
    * Initializes an empty B+ tree.
    * @param compare Custom function to compare pairs of elements in the tree.
@@ -207,7 +207,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
     if (entries)
       this.setPairs(entries);
   }
-  
+
   /////////////////////////////////////////////////////////////////////////////
   // ES6 Map<K,V> methods /////////////////////////////////////////////////////
 
@@ -226,9 +226,9 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
 
   forEach(callback: (v:V, k:K, tree:BTree<K,V>) => void, thisArg?: any): number;
 
-  /** Runs a function for each key-value pair, in order from smallest to 
+  /** Runs a function for each key-value pair, in order from smallest to
    *  largest key. For compatibility with ES6 Map, the argument order to
-   *  the callback is backwards: value first, then key. Call forEachPair 
+   *  the callback is backwards: value first, then key. Call forEachPair
    *  instead to receive the key as the first argument.
    * @param thisArg If provided, this parameter is assigned as the `this`
    *        value for each callback.
@@ -240,16 +240,16 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
     return this.forEachPair((k, v) => callback(v, k, this));
   }
 
-  /** Runs a function for each key-value pair, in order from smallest to 
+  /** Runs a function for each key-value pair, in order from smallest to
    *  largest key. The callback can return {break:R} (where R is any value
    *  except undefined) to stop immediately and return R from forEachPair.
-   * @param onFound A function that is called for each key-value pair. This 
+   * @param onFound A function that is called for each key-value pair. This
    *        function can return {break:R} to stop early with result R.
-   *        The reason that you must return {break:R} instead of simply R 
-   *        itself is for consistency with editRange(), which allows 
+   *        The reason that you must return {break:R} instead of simply R
+   *        itself is for consistency with editRange(), which allows
    *        multiple actions, not just breaking.
-   * @param initialCounter This is the value of the third argument of 
-   *        `onFound` the first time it is called. The counter increases 
+   * @param initialCounter This is the value of the third argument of
+   *        `onFound` the first time it is called. The counter increases
    *        by one each time `onFound` is called. Default value: 0
    * @returns the number of pairs sent to the callback (plus initialCounter,
    *        if you provided one). If the callback returned {break:R} then
@@ -268,13 +268,13 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
   get(key: K, defaultValue?: V): V | undefined {
     return this._root.get(key, defaultValue, this);
   }
-  
+
   /**
    * Adds or overwrites a key-value pair in the B+ tree.
    * @param key the key is used to determine the sort order of
    *        data in the tree.
    * @param value data to associate with the key (optional)
-   * @param overwrite Whether to overwrite an existing key-value pair 
+   * @param overwrite Whether to overwrite an existing key-value pair
    *        (default: true). If this is false and there is an existing
    *        key-value pair then this method has no effect.
    * @returns true if a new key-value pair was added.
@@ -283,7 +283,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
    * as well as the value. This has no effect unless the new key
    * has data that does not affect its sort order.
    */
-  set(key: K, value: V, overwrite?: boolean): boolean { 
+  set(key: K, value: V, overwrite?: boolean): boolean {
     if (this._root.isShared)
       this._root = this._root.clone();
     var result = this._root.set(key, value, overwrite, this);
@@ -301,7 +301,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
    * @param key Key to detect
    * @description Computational complexity: O(log size)
    */
-  has(key: K): boolean { 
+  has(key: K): boolean {
     return this.forRange(key, key, true, undefined) !== 0;
   }
 
@@ -333,10 +333,10 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
     return nu.setPairs(pairs, overwrite) !== 0 || overwrite ? nu : this;
   }
 
-  /** Returns a copy of the tree with the specified keys present. 
+  /** Returns a copy of the tree with the specified keys present.
    *  @param keys The keys to add. If a key is already present in the tree,
    *         neither the existing key nor the existing value is modified.
-   *  @param returnThisIfUnchanged if true, returns this if all keys already 
+   *  @param returnThisIfUnchanged if true, returns this if all keys already
    *  existed. Performance note: due to the architecture of this class, all
    *  node(s) leading to existing keys are cloned even if the collection is
    *  ultimately unchanged.
@@ -348,7 +348,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
     return returnThisIfUnchanged && !changed ? this : nu;
   }
 
-  /** Returns a copy of the tree with the specified key removed. 
+  /** Returns a copy of the tree with the specified key removed.
    * @param returnThisIfUnchanged if true, returns this if the key didn't exist.
    *  Performance note: due to the architecture of this class, node(s) leading
    *  to where the key would have been stored are cloned even when the key
@@ -377,7 +377,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
     return nu;
   }
 
-  /** Returns a copy of the tree with pairs removed whenever the callback 
+  /** Returns a copy of the tree with pairs removed whenever the callback
    *  function returns false. `where()` is a synonym for this method. */
   filter(callback: (k:K,v:V,counter:number) => boolean, returnThisIfUnchanged?: boolean): BTree<K,V> {
     var nu = this.greedyClone();
@@ -400,16 +400,16 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
     return nu as any as BTree<K,R>;
   }
 
-  /** Performs a reduce operation like the `reduce` method of `Array`. 
-   *  It is used to combine all pairs into a single value, or perform 
+  /** Performs a reduce operation like the `reduce` method of `Array`.
+   *  It is used to combine all pairs into a single value, or perform
    *  conversions. `reduce` is best understood by example. For example,
-   *  `tree.reduce((P, pair) => P * pair[0], 1)` multiplies all keys 
-   *  together. It means "start with P=1, and for each pair multiply 
-   *  it by the key in pair[0]". Another example would be converting 
+   *  `tree.reduce((P, pair) => P * pair[0], 1)` multiplies all keys
+   *  together. It means "start with P=1, and for each pair multiply
+   *  it by the key in pair[0]". Another example would be converting
    *  the tree to a Map (in this example, note that M.set returns M):
-   *  
+   *
    *  var M = tree.reduce((M, pair) => M.set(pair[0],pair[1]), new Map())
-   *  
+   *
    *  **Note**: the same array is sent to the callback on every iteration.
    */
   reduce<R>(callback: (previous:R,currentPair:[K,V],counter:number,tree:BTree<K,V>) => R, initialValue: R): R;
@@ -479,7 +479,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
   }
 
   /** Returns an iterator that provides items in reversed order.
-   *  @param highestKey Key at which to start iterating, or undefined to 
+   *  @param highestKey Key at which to start iterating, or undefined to
    *         start at maxKey(). If the specified key doesn't exist then iteration
    *         starts at the next lower key (according to the comparator).
    *  @param reusedArray Optional array used repeatedly to store key-value
@@ -541,9 +541,9 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
 
   /* Used by entries() and entriesReversed() to prepare to start iterating.
    * It develops a "node queue" for each non-leaf level of the tree.
-   * Levels are numbered "bottom-up" so that level 0 is a list of leaf 
+   * Levels are numbered "bottom-up" so that level 0 is a list of leaf
    * nodes from a low-level non-leaf node. The queue at a given level L
-   * consists of nodequeue[L] which is the children of a BNodeInternal, 
+   * consists of nodequeue[L] which is the children of a BNodeInternal,
    * and nodeindex[L], the current index within that child list, such
    * such that nodequeue[L-1] === nodequeue[L][nodeindex[L]].children.
    * (However inside this function the order is reversed.)
@@ -573,8 +573,8 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
   /**
    * Computes the differences between `this` and `other`.
    * For efficiency, the diff is returned via invocations of supplied handlers.
-   * The computation is optimized for the case in which the two trees have large amounts 
-   * of shared data (obtained by calling the `clone` or `with` APIs) and will avoid 
+   * The computation is optimized for the case in which the two trees have large amounts
+   * of shared data (obtained by calling the `clone` or `with` APIs) and will avoid
    * any iteration of shared state.
    * The handlers can cause computation to early exit by returning {break: R}.
    * Neither of the collections should be changed during the comparison process (in your callbacks), as this method assumes they will not be mutated.
@@ -610,14 +610,14 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
     //    - If either cursor points to a key/value pair:
     //      - If thisCursor === otherCursor and the values differ, it is a Different.
     //      - If thisCursor > otherCursor and otherCursor is at a key/value pair, it is an OnlyOther.
-    //      - If thisCursor < otherCursor and thisCursor is at a key/value pair, it is an OnlyThis as long as the most recent 
-    //        cursor step was *not* otherCursor advancing from a tie. The extra condition avoids erroneous OnlyOther calls 
+    //      - If thisCursor < otherCursor and thisCursor is at a key/value pair, it is an OnlyThis as long as the most recent
+    //        cursor step was *not* otherCursor advancing from a tie. The extra condition avoids erroneous OnlyOther calls
     //        that would occur due to otherCursor being the "leader".
     //    - Otherwise, if both cursors point to nodes, compare them. If they are equal by reference (shared), skip
     //      both cursors to the next node in the walk.
     // - Once one cursor has finished stepping, any remaining steps (if any) are taken and key/value pairs are logged
     //   as OnlyOther (if otherCursor is stepping) or OnlyThis (if thisCursor is stepping).
-    // This algorithm gives the critical guarantee that all locations (both nodes and key/value pairs) in both trees that 
+    // This algorithm gives the critical guarantee that all locations (both nodes and key/value pairs) in both trees that
     // are identical by value (and possibly by reference) will be visited *at the same time* by the cursors.
     // This removes the possibility of emitting incorrect diffs, as well as allowing for skipping shared nodes.
     const { _compare } = this;
@@ -738,7 +738,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
    * @param cursor The cursor to step
    * @param stepToNode If true, the cursor will be advanced to the next node (skipping values)
    * @returns true if the step was completed and false if the step would have caused the cursor to move beyond the end of the tree.
-   */ 
+   */
   private static step<K, V>(cursor: DiffCursor<K, V>, stepToNode?: boolean): boolean {
     const { internalSpine, levelIndices, leaf } = cursor;
     if (stepToNode === true || leaf) {
@@ -825,7 +825,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
   // End of helper methods for diffAgainst //////////////////////////////////
   ///////////////////////////////////////////////////////////////////////////
 
-  /** Returns a new iterator for iterating the keys of each pair in ascending order. 
+  /** Returns a new iterator for iterating the keys of each pair in ascending order.
    *  @param firstKey: Minimum key to include in the output. */
   keys(firstKey?: K): IterableIterator<K> {
     var it = this.entries(firstKey, ReusedArray);
@@ -835,8 +835,8 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
       return n;
     });
   }
-  
-  /** Returns a new iterator for iterating the values of each pair in order by key. 
+
+  /** Returns a new iterator for iterating the values of each pair in order by key.
    *  @param firstKey: Minimum key whose associated value is included in the output. */
   values(firstKey?: K): IterableIterator<V> {
     var it = this.entries(firstKey, ReusedArray);
@@ -857,11 +857,11 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
 
   /** Gets the lowest key in the tree. Complexity: O(log size) */
   minKey(): K | undefined { return this._root.minKey(); }
-  
+
   /** Gets the highest key in the tree. Complexity: O(1) */
   maxKey(): K | undefined { return this._root.maxKey(); }
 
-  /** Quickly clones the tree by marking the root node as shared. 
+  /** Quickly clones the tree by marking the root node as shared.
    *  Both copies remain editable. When you modify either copy, any
    *  nodes that are shared (or potentially shared) between the two
    *  copies are cloned so that the changes do not affect other copies.
@@ -874,8 +874,8 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
     return result;
   }
 
-  /** Performs a greedy clone, immediately duplicating any nodes that are 
-   *  not currently marked as shared, in order to avoid marking any 
+  /** Performs a greedy clone, immediately duplicating any nodes that are
+   *  not currently marked as shared, in order to avoid marking any
    *  additional nodes as shared.
    *  @param force Clone all nodes, even shared ones.
    */
@@ -897,11 +897,11 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
   /** Gets an array of all keys, sorted */
   keysArray() {
     var results: K[] = [];
-    this._root.forRange(this.minKey()!, this.maxKey()!, true, false, this, 0, 
+    this._root.forRange(this.minKey()!, this.maxKey()!, true, false, this, 0,
       (k,v) => { results.push(k); });
     return results;
   }
-  
+
   /** Gets an array of all values, sorted by key */
   valuesArray() {
     var results: V[] = [];
@@ -915,7 +915,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
     return this.toArray().toString();
   }
 
-  /** Stores a key-value pair only if the key doesn't already exist in the tree. 
+  /** Stores a key-value pair only if the key doesn't already exist in the tree.
    * @returns true if a new key was added
   */
   setIfNotPresent(key: K, value: V): boolean {
@@ -925,7 +925,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
   /** Returns the next pair whose key is larger than the specified key (or undefined if there is none).
    * If key === undefined, this function returns the lowest pair.
    * @param key The key to search for.
-   * @param reusedArray Optional array used repeatedly to store key-value pairs, to 
+   * @param reusedArray Optional array used repeatedly to store key-value pairs, to
    * avoid creating a new array on every iteration.
    */
   nextHigherPair(key: K|undefined, reusedArray?: [K,V]): [K,V]|undefined {
@@ -935,7 +935,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
     }
     return this._root.getPairOrNextHigher(key, this._compare, false, reusedArray);
   }
-  
+
   /** Returns the next key larger than the specified key, or undefined if there is none.
    *  Also, nextHigherKey(undefined) returns the lowest key.
    */
@@ -947,7 +947,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
   /** Returns the next pair whose key is smaller than the specified key (or undefined if there is none).
    *  If key === undefined, this function returns the highest pair.
    * @param key The key to search for.
-   * @param reusedArray Optional array used repeatedly to store key-value pairs, to 
+   * @param reusedArray Optional array used repeatedly to store key-value pairs, to
    *        avoid creating a new array each time you call this method.
    */
   nextLowerPair(key: K|undefined, reusedArray?: [K,V]): [K,V]|undefined {
@@ -957,7 +957,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
     }
     return this._root.getPairOrNextLower(key, this._compare, false, reusedArray);
   }
-  
+
   /** Returns the next key smaller than the specified key, or undefined if there is none.
    *  Also, nextLowerKey(undefined) returns the highest key.
    */
@@ -966,32 +966,32 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
     return p && p[0];
   }
 
-  /** Returns the key-value pair associated with the supplied key if it exists 
+  /** Returns the key-value pair associated with the supplied key if it exists
    *  or the pair associated with the next lower pair otherwise. If there is no
    *  next lower pair, undefined is returned.
    * @param key The key to search for.
-   * @param reusedArray Optional array used repeatedly to store key-value pairs, to 
+   * @param reusedArray Optional array used repeatedly to store key-value pairs, to
    *        avoid creating a new array each time you call this method.
    * */
   getPairOrNextLower(key: K, reusedArray?: [K,V]): [K,V]|undefined {
     return this._root.getPairOrNextLower(key, this._compare, true, reusedArray || ([] as unknown as [K,V]));
   }
 
-  /** Returns the key-value pair associated with the supplied key if it exists 
+  /** Returns the key-value pair associated with the supplied key if it exists
    *  or the pair associated with the next lower pair otherwise. If there is no
    *  next lower pair, undefined is returned.
    * @param key The key to search for.
-   * @param reusedArray Optional array used repeatedly to store key-value pairs, to 
+   * @param reusedArray Optional array used repeatedly to store key-value pairs, to
    *        avoid creating a new array each time you call this method.
    * */
   getPairOrNextHigher(key: K, reusedArray?: [K,V]): [K,V]|undefined {
     return this._root.getPairOrNextHigher(key, this._compare, true, reusedArray || ([] as unknown as [K,V]));
   }
 
-  /** Edits the value associated with a key in the tree, if it already exists. 
+  /** Edits the value associated with a key in the tree, if it already exists.
    * @returns true if the key existed, false if not.
   */
-  changeIfPresent(key: K, value: V): boolean { 
+  changeIfPresent(key: K, value: V): boolean {
     return this.editRange(key, key, true, (k,v) => ({value})) !== 0;
   }
 
@@ -1003,7 +1003,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
    * @param includeHigh If the `high` key is present, its pair will be included
    *        in the output if and only if this parameter is true. Note: if the
    *        `low` key is present, it is always included in the output.
-   * @param maxLength Length limit. getRange will stop scanning the tree when 
+   * @param maxLength Length limit. getRange will stop scanning the tree when
    *                  the array reaches this size.
    * @description Computational complexity: O(result.length + log size)
    */
@@ -1017,8 +1017,8 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
   }
 
   /** Adds all pairs from a list of key-value pairs.
-   * @param pairs Pairs to add to this tree. If there are duplicate keys, 
-   *        later pairs currently overwrite earlier ones (e.g. [[0,1],[0,7]] 
+   * @param pairs Pairs to add to this tree. If there are duplicate keys,
+   *        later pairs currently overwrite earlier ones (e.g. [[0,1],[0,7]]
    *        associates 0 with 7.)
    * @param overwrite Whether to overwrite pairs that already exist (if false,
    *        pairs[i] is ignored when the key pairs[i][0] already exists.)
@@ -1038,17 +1038,17 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
   /**
    * Scans the specified range of keys, in ascending order by key.
    * Note: the callback `onFound` must not insert or remove items in the
-   * collection. Doing so may cause incorrect data to be sent to the 
+   * collection. Doing so may cause incorrect data to be sent to the
    * callback afterward.
    * @param low The first key scanned will be greater than or equal to `low`.
    * @param high Scanning stops when a key larger than this is reached.
    * @param includeHigh If the `high` key is present, `onFound` is called for
    *        that final pair if and only if this parameter is true.
-   * @param onFound A function that is called for each key-value pair. This 
+   * @param onFound A function that is called for each key-value pair. This
    *        function can return {break:R} to stop early with result R.
-   * @param initialCounter Initial third argument of onFound. This value 
+   * @param initialCounter Initial third argument of onFound. This value
    *        increases by one each time `onFound` is called. Default: 0
-   * @returns The number of values found, or R if the callback returned 
+   * @returns The number of values found, or R if the callback returned
    *        `{break:R}` to stop early.
    * @description Computational complexity: O(number of items scanned + log size)
    */
@@ -1059,31 +1059,31 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
 
   /**
    * Scans and potentially modifies values for a subsequence of keys.
-   * Note: the callback `onFound` should ideally be a pure function. 
-   *   Specfically, it must not insert items, call clone(), or change 
+   * Note: the callback `onFound` should ideally be a pure function.
+   *   Specfically, it must not insert items, call clone(), or change
    *   the collection except via return value; out-of-band editing may
    *   cause an exception or may cause incorrect data to be sent to
-   *   the callback (duplicate or missed items). It must not cause a 
+   *   the callback (duplicate or missed items). It must not cause a
    *   clone() of the collection, otherwise the clone could be modified
    *   by changes requested by the callback.
    * @param low The first key scanned will be greater than or equal to `low`.
    * @param high Scanning stops when a key larger than this is reached.
    * @param includeHigh If the `high` key is present, `onFound` is called for
    *        that final pair if and only if this parameter is true.
-   * @param onFound A function that is called for each key-value pair. This 
-   *        function can return `{value:v}` to change the value associated 
+   * @param onFound A function that is called for each key-value pair. This
+   *        function can return `{value:v}` to change the value associated
    *        with the current key, `{delete:true}` to delete the current pair,
    *        `{break:R}` to stop early with result R, or it can return nothing
    *        (undefined or {}) to cause no effect and continue iterating.
    *        `{break:R}` can be combined with one of the other two commands.
-   *        The third argument `counter` is the number of items iterated 
+   *        The third argument `counter` is the number of items iterated
    *        previously; it equals 0 when `onFound` is called the first time.
-   * @returns The number of values scanned, or R if the callback returned 
+   * @returns The number of values scanned, or R if the callback returned
    *        `{break:R}` to stop early.
-   * @description 
+   * @description
    *   Computational complexity: O(number of items scanned + log size)
    *   Note: if the tree has been cloned with clone(), any shared
-   *   nodes are copied before `onFound` is called. This takes O(n) time 
+   *   nodes are copied before `onFound` is called. This takes O(n) time
    *   where n is proportional to the amount of shared data scanned.
    */
   editRange<R=V>(low: K, high: K, includeHigh: boolean, onFound: (k:K,v:V,counter:number) => EditRangeResult<V,R>|void, initialCounter?: number): R|number {
@@ -1132,7 +1132,7 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
     return r;
   }
 
-  /** Gets the height of the tree: the number of internal nodes between the 
+  /** Gets the height of the tree: the number of internal nodes between the
    *  BTree object and its leaf nodes (zero if there are no internal nodes). */
   get height(): number {
     let node: BNode<K, V> | undefined = this._root;
@@ -1146,13 +1146,13 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
 
   /** Makes the object read-only to ensure it is not accidentally modified.
    *  Freezing does not have to be permanent; unfreeze() reverses the effect.
-   *  This is accomplished by replacing mutator functions with a function 
-   *  that throws an Error. Compared to using a property (e.g. this.isFrozen) 
+   *  This is accomplished by replacing mutator functions with a function
+   *  that throws an Error. Compared to using a property (e.g. this.isFrozen)
    *  this implementation gives better performance in non-frozen BTrees.
    */
   freeze() {
     var t = this as any;
-    // Note: all other mutators ultimately call set() or editRange() 
+    // Note: all other mutators ultimately call set() or editRange()
     //       so we don't need to override those others.
     t.clear = t.set = t.editRange = function() {
       throw new Error("Attempted to modify a frozen BTree");
@@ -1186,10 +1186,10 @@ export default class BTree<K=any, V=any> implements ISortedMapF<K,V>, ISortedMap
   }
 }
 
-/** A TypeScript helper function that simply returns its argument, typed as 
+/** A TypeScript helper function that simply returns its argument, typed as
  *  `ISortedSet<K>` if the BTree implements it, as it does if `V extends undefined`.
  *  If `V` cannot be `undefined`, it returns `unknown` instead. Or at least, that
- *  was the intention, but TypeScript is acting weird and may return `ISortedSet<K>` 
+ *  was the intention, but TypeScript is acting weird and may return `ISortedSet<K>`
  *  even if `V` can't be `undefined` (discussion: btree-typescript issue #14) */
 export function asSet<K,V>(btree: BTree<K,V>): undefined extends V ? ISortedSet<K> : unknown {
   return btree as any;
@@ -1221,7 +1221,7 @@ class BNode<K,V> {
   // in those children. (Certain operations will propagate isShared=true to children.)
   isShared: true | undefined;
   get isLeaf() { return (this as any).children === undefined; }
-  
+
   constructor(keys: K[] = [], values?: V[]) {
     this.keys = keys;
     this.values = values || undefVals as any[];
@@ -1371,7 +1371,7 @@ class BNode<K,V> {
     check(this.values === undefVals ? kL <= vL : kL === vL,
       "keys/values length mismatch: depth", depth, "with lengths", kL, vL, "and baseIndex", baseIndex);
     // Note: we don't check for "node too small" because sometimes a node
-    // can legitimately have size 1. This occurs if there is a batch 
+    // can legitimately have size 1. This occurs if there is a batch
     // deletion, leaving a node of size 1, and the siblings are full so
     // it can't be merged with adjacent nodes. However, the parent will
     // verify that the average node size is at least half of the maximum.
@@ -1382,13 +1382,13 @@ class BNode<K,V> {
   /////////////////////////////////////////////////////////////////////////////
   // Leaf Node: set & node splitting //////////////////////////////////////////
 
-  set(key: K, value: V, overwrite: boolean|undefined, tree: BTree<K,V>): boolean|BNode<K,V> { 
+  set(key: K, value: V, overwrite: boolean|undefined, tree: BTree<K,V>): boolean|BNode<K,V> {
     var i = this.indexOf(key, -1, tree._compare);
     if (i < 0) {
       // key does not exist yet
       i = ~i;
       tree._size++;
-      
+
       if (this.keys.length < tree._maxNodeSize) {
         return this.insertInLeaf(i, key, value, tree);
       } else {
@@ -1434,7 +1434,7 @@ class BNode<K,V> {
     this.values.splice(i, 0, value);
     return true;
   }
-  
+
   takeFromRight(rhs: BNode<K,V>) {
     // Reminder: parent node must update its copy of key for this node
     // assert: neither node is shared
@@ -1536,12 +1536,12 @@ class BNode<K,V> {
 
 /** Internal node (non-leaf node) ********************************************/
 class BNodeInternal<K,V> extends BNode<K,V> {
-  // Note: conventionally B+ trees have one fewer key than the number of 
+  // Note: conventionally B+ trees have one fewer key than the number of
   // children, but I find it easier to keep the array lengths equal: each
   // keys[i] caches the value of children[i].maxKey().
   children: BNode<K,V>[];
 
-  /** 
+  /**
    * This does not mark `children` as shared, so it is the responsibility of the caller
    * to ensure children are either marked shared, or aren't included in another tree.
    */
@@ -1639,7 +1639,7 @@ class BNodeInternal<K,V> extends BNode<K,V> {
   set(key: K, value: V, overwrite: boolean|undefined, tree: BTree<K,V>): boolean|BNodeInternal<K,V> {
     var c = this.children, max = tree._maxNodeSize, cmp = tree._compare;
     var i = Math.min(this.indexOf(key, 0, cmp), c.length - 1), child = c[i];
-    
+
     if (child.isShared)
       c[i] = child = child.clone();
     if (child.keys.length >= max) {
@@ -1683,7 +1683,7 @@ class BNodeInternal<K,V> extends BNode<K,V> {
     }
   }
 
-  /** 
+  /**
    * Inserts `child` at index `i`.
    * This does not mark `child` as shared, so it is the responsibility of the caller
    * to ensure that either child is marked shared, or it is not included in another tree.
@@ -1722,7 +1722,7 @@ class BNodeInternal<K,V> extends BNode<K,V> {
   /////////////////////////////////////////////////////////////////////////////
   // Internal Node: scanning & deletions //////////////////////////////////////
 
-  // Note: `count` is the next value of the third argument to `onFound`. 
+  // Note: `count` is the next value of the third argument to `onFound`.
   //       A leaf node's `forRange` function returns a new value for this counter,
   //       unless the operation is to stop early.
   forRange<R>(low: K, high: K, includeHigh: boolean|undefined, editMode: boolean, tree: BTree<K,V>, count: number,
@@ -1820,13 +1820,13 @@ class BNodeInternal<K,V> extends BNode<K,V> {
 
 /**
  * A walkable pointer into a BTree for computing efficient diffs between trees with shared data.
- * - A cursor points to either a key/value pair (KVP) or a node (which can be either a leaf or an internal node). 
+ * - A cursor points to either a key/value pair (KVP) or a node (which can be either a leaf or an internal node).
  *    As a consequence, a cursor cannot be created for an empty tree.
- * - A cursor can be walked forwards using `step`. A cursor can be compared to another cursor to 
+ * - A cursor can be walked forwards using `step`. A cursor can be compared to another cursor to
  *    determine which is ahead in advancement.
- * - A cursor is valid only for the tree it was created from, and only until the first edit made to 
+ * - A cursor is valid only for the tree it was created from, and only until the first edit made to
  *    that tree since the cursor's creation.
- * - A cursor contains a key for the current location, which is the maxKey when the cursor points to a node 
+ * - A cursor contains a key for the current location, which is the maxKey when the cursor points to a node
  *    and a key corresponding to a value when pointing to a leaf.
  * - Leaf is only populated if the cursor points to a KVP. If this is the case, levelIndices.length === internalSpine.length + 1
  *    and levelIndices[levelIndices.length - 1] is the index of the value.
@@ -1848,7 +1848,7 @@ var undefVals: any[] = [];
 
 const Delete = {delete: true}, DeleteRange = () => Delete;
 const Break = {break: true};
-const EmptyLeaf = (function() { 
+const EmptyLeaf = (function() {
   var n = new BNode<any,any>(); n.isShared = true; return n;
 })();
 const EmptyArray: any[] = [];

--- a/benchmarks.ts
+++ b/benchmarks.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env ts-node
-import BTree, {IMap} from '.';
+import { BTree, IMap} from '.';
 import SortedArray from './sorted-array';
 // Note: The `bintrees` package also includes a `BinTree` type which turned
 // out to be an unbalanced binary tree. It is faster than `RBTree` for
-// randomized data, but it becomes extremely slow when filled with sorted 
+// randomized data, but it becomes extremely slow when filled with sorted
 // data, so it's not usually a good choice.
 import {RBTree} from 'bintrees';
 const SortedSet = require("collections/sorted-set");         // Bad type definition: missing 'length'
@@ -29,7 +29,7 @@ function makeArray(size: number, randomOrder: boolean, spacing = 10) {
   for (i = 0, n = 0; i < size; i++, n += 1 + randInt(spacing))
     keys[i] = n;
   if (randomOrder)
-    for (i = 0; i < size; i++) 
+    for (i = 0; i < size; i++)
       swap(keys, i, randInt(size));
   return keys;
 }
@@ -153,10 +153,10 @@ for (let size of [9999, 1000, 10000, 100000, 1000000]) {
   //  return set;
   //});
 
-  // Bug fix: can't use measure() for deletions because the 
+  // Bug fix: can't use measure() for deletions because the
   //          trees aren't the same on the second iteration
   var timer = new Timer();
-  
+
   for (i = 0; i < keys.length; i += 2)
     btree.delete(keys[i]);
   log(`${timer.restart()}\tDelete every second item in B+ tree`);
@@ -195,7 +195,7 @@ for (let size of [9999, 1000, 10000, 100000, 1000000]) {
   var log = (size === 9999 ? () => {} : console.log);
   var keys = makeArray(size, true);
   log();
-  
+
   if (size <= 100000) {
     measure(list => `Insert ${list.size} pairs in sorted array`, () => {
       let list = new SortedArray();
@@ -291,7 +291,7 @@ for (let size of [1000, 10000, 100000, 1000000]) {
     for (i = keys.length-1; i >= 0; i -= 2)
       tree.delete(keys[i]);
   });
-  
+
   measure(() => `Delete every second item in Map hashtable`, () => {
     for (i = keys.length-1; i >= 0; i -= 2)
       map.delete(keys[i]);
@@ -343,7 +343,7 @@ console.log("### Delta between B+ trees");
       const tree = new BTree();
       for (let k of keys.slice(0, size))
         tree.set(k, k * 10);
-      
+
       const otherTree = tree.clone();
       for (let k of keys.slice(size))
         tree.set(k, k * 10);

--- a/sorted-array.js
+++ b/sorted-array.js
@@ -1,56 +1,49 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 /** A super-inefficient sorted list for testing purposes */
-var SortedArray = /** @class */ (function () {
-    function SortedArray(entries, compare) {
-        this.cmp = compare || (function (a, b) { return a < b ? -1 : a > b ? 1 : a === b ? 0 : a - b; });
+class SortedArray {
+    constructor(entries, compare) {
+        this.cmp = compare || ((a, b) => a < b ? -1 : a > b ? 1 : a === b ? 0 : a - b);
         this.a = [];
         if (entries !== undefined)
-            for (var _i = 0, entries_1 = entries; _i < entries_1.length; _i++) {
-                var e = entries_1[_i];
+            for (var e of entries)
                 this.set(e[0], e[1]);
-            }
     }
-    Object.defineProperty(SortedArray.prototype, "size", {
-        get: function () { return this.a.length; },
-        enumerable: false,
-        configurable: true
-    });
-    SortedArray.prototype.get = function (key, defaultValue) {
+    get size() { return this.a.length; }
+    get(key, defaultValue) {
         var pair = this.a[this.indexOf(key, -1)];
         return pair === undefined ? defaultValue : pair[1];
-    };
-    SortedArray.prototype.set = function (key, value, overwrite) {
+    }
+    set(key, value, overwrite) {
         var i = this.indexOf(key, -1);
         if (i <= -1)
             this.a.splice(~i, 0, [key, value]);
         else
             this.a[i] = [key, value];
         return i <= -1;
-    };
-    SortedArray.prototype.has = function (key) {
+    }
+    has(key) {
         return this.indexOf(key, -1) >= 0;
-    };
-    SortedArray.prototype.delete = function (key) {
+    }
+    delete(key) {
         var i = this.indexOf(key, -1);
         if (i > -1)
             this.a.splice(i, 1);
         return i > -1;
-    };
-    SortedArray.prototype.clear = function () { this.a = []; };
-    SortedArray.prototype.getArray = function () { return this.a; };
-    SortedArray.prototype.minKey = function () { return this.a[0][0]; };
-    SortedArray.prototype.maxKey = function () { return this.a[this.a.length - 1][0]; };
-    SortedArray.prototype.forEach = function (callbackFn) {
-        var _this = this;
-        this.a.forEach(function (pair) { return callbackFn(pair[1], pair[0], _this); });
-    };
+    }
+    clear() { this.a = []; }
+    getArray() { return this.a; }
+    minKey() { return this.a[0][0]; }
+    maxKey() { return this.a[this.a.length - 1][0]; }
+    forEach(callbackFn) {
+        this.a.forEach(pair => callbackFn(pair[1], pair[0], this));
+    }
     // a.values() used to implement IMap<K,V> but it's not actually available in Node v10.4
-    SortedArray.prototype[Symbol.iterator] = function () { return this.a.values(); };
-    SortedArray.prototype.entries = function () { return this.a.values(); };
-    SortedArray.prototype.keys = function () { return this.a.map(function (pair) { return pair[0]; }).values(); };
-    SortedArray.prototype.values = function () { return this.a.map(function (pair) { return pair[1]; }).values(); };
-    SortedArray.prototype.indexOf = function (key, failXor) {
+    [Symbol.iterator]() { return this.a.values(); }
+    entries() { return this.a.values(); }
+    keys() { return this.a.map(pair => pair[0]).values(); }
+    values() { return this.a.map(pair => pair[1]).values(); }
+    indexOf(key, failXor) {
         var lo = 0, hi = this.a.length, mid = hi >> 1;
         while (lo < hi) {
             var c = this.cmp(this.a[mid][0], key);
@@ -65,7 +58,6 @@ var SortedArray = /** @class */ (function () {
             mid = (lo + hi) >> 1;
         }
         return mid ^ failXor;
-    };
-    return SortedArray;
-}());
+    }
+}
 exports.default = SortedArray;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
-{ // TypeScript configuration file: provides options to the TypeScript 
+{ // TypeScript configuration file: provides options to the TypeScript
   // compiler (tsc) and makes VSCode recognize this folder as a TS project,
   // enabling the VSCode build tasks "tsc: build" and "tsc: watch".
   "compilerOptions": {
-    "target": "es5",            // Compatible with older browsers
-    "module": "commonjs",       // Compatible with both Node.js and browser
-    "moduleResolution": "node", // Tell tsc to look in node_modules for modules
+    "target": "es2020",            // Compatible with older browsers
+    "module": "node16",       // Compatible with both Node.js and browser
+    "moduleResolution": "node16", // Tell tsc to look in node_modules for modules
     "sourceMap": false,         // Whether to create *.js.map files
     "jsx": "react",             // Causes inline XML (JSX code) to be expanded
     "strict": true,             // Strict types, eg. prohibits `var x=0; x=null`


### PR DESCRIPTION
Changes:

- Update tsconfig.
- Use named export instead of default export for `BTree`
- Add `override` keyword as necessary (came up from trying to use this patch in a project with `module: esnext` + `moduleResolution: node`).

The rest is just auto-formatting like removing trailing spaces.